### PR TITLE
Removed dead code in lapic.c and defs.h

### DIFF
--- a/defs.h
+++ b/defs.h
@@ -13,10 +13,8 @@ void            ioapicinit(void);
 void            cmostime(struct rtcdate *r);
 int             lapicid(void);
 extern volatile uint*    lapic;
-void            lapiceoi(void);
 void            lapicinit(void);
 void            lapicstartap(uchar, uint);
-void            microdelay(int);
 
 // mp.c
 extern int      ismp;

--- a/lapic.c
+++ b/lapic.c
@@ -102,18 +102,3 @@ lapicid(void)
     return 0;
   return lapic[ID] >> 24;
 }
-
-// Acknowledge interrupt.
-void
-lapiceoi(void)
-{
-  if(lapic)
-    lapicw(EOI, 0);
-}
-
-// Spin for a given number of microseconds.
-// On real hardware would want to tune this dynamically.
-void
-microdelay(int us)
-{
-}


### PR DESCRIPTION
The following functions were not used in this branch
```void            lapiceoi(void);```
```void            microdelay(int);```