### PR TITLE
Update fs.c, released buff in bmap using brelse

### DIFF
--- a/fs.c
+++ b/fs.c
@@ -136,6 +136,7 @@ static uint
 bmap(struct inode *ip, uint bn)
 {
   struct buf *bp;
+  uint addr;
 
   if(bn < NDIRECT){
     return ip->addrs[bn];
@@ -146,7 +147,9 @@ bmap(struct inode *ip, uint bn)
     // Load indirect block
     bp = bread(ip->dev, ip->addrs[NDIRECT]);
     uint *a = (uint*)bp->data;
-    return a[bn];
+    addr = a[bn];
+    brelse(bp);
+    return addr;
   }
 
   panic("bmap: out of range");


### PR DESCRIPTION
Earlier bp (buffer block) was not released in bmap. It is done using brelse and the corresponding block address is released.