### PR TITLE
Corrected sp calculation in allocproc() and segment limits in seginit()

### DIFF
--- a/proc.c
+++ b/proc.c
@@ -55,7 +55,7 @@ found:
   p->state = EMBRYO;
   p->pid = nextpid++;
 
-  sp = (char*)(STARTPROC + (PROCSIZE>>12));
+  sp = (char*)(STARTPROC + (PROCSIZE << 12));
 
   // Allocate kernel stack.
   p->kstack = sp - KSTACKSIZE;

--- a/vm.c
+++ b/vm.c
@@ -20,8 +20,8 @@ seginit(void)
   c = &cpus[cpuid()];
   c->gdt[SEG_KCODE] = SEG(STA_X|STA_R, 0, 0xffffffff, 0);
   c->gdt[SEG_KDATA] = SEG(STA_W, 0, 0xffffffff, 0);
-  c->gdt[SEG_UCODE] = SEG(STA_X|STA_R, STARTPROC, (PROCSIZE << 12) - 1, DPL_USER);
-  c->gdt[SEG_UDATA] = SEG(STA_W, STARTPROC, (PROCSIZE << 12) - 1, DPL_USER);
+  c->gdt[SEG_UCODE] = SEG(STA_X|STA_R, STARTPROC, (PROCSIZE << 12) - 2, DPL_USER);
+  c->gdt[SEG_UDATA] = SEG(STA_W, STARTPROC, (PROCSIZE << 12) - 2, DPL_USER);
   lgdt(c->gdt, sizeof(c->gdt));
 }
 


### PR DESCRIPTION
1. sp calculation should have left shift instead of right shift.
2. Segment descriptors store (size of segment - 1) as limit. Since last 4KB is for kernel stack, this should have "-2" instead of "-1".