### PR TITLE
[changed user process segment limits(in vm.c) and changed stack pointer calculation (in proc.c)]

### DIFF
--- a/proc.c
+++ b/proc.c
@@ -55,7 +55,7 @@ found:
   p->state = EMBRYO;
   p->pid = nextpid++;
 
-  sp = (char*)(STARTPROC + (PROCSIZE>>12));
+  sp = (char*)(STARTPROC + (PROCSIZE<<12));
 
   // Allocate kernel stack.
   p->kstack = sp - KSTACKSIZE;

--- a/vm.c
+++ b/vm.c
@@ -20,8 +20,8 @@ seginit(void)
   c = &cpus[cpuid()];
   c->gdt[SEG_KCODE] = SEG(STA_X|STA_R, 0, 0xffffffff, 0);
   c->gdt[SEG_KDATA] = SEG(STA_W, 0, 0xffffffff, 0);
-  c->gdt[SEG_UCODE] = SEG(STA_X|STA_R, STARTPROC, (PROCSIZE << 12) - 1, DPL_USER);
-  c->gdt[SEG_UDATA] = SEG(STA_W, STARTPROC, (PROCSIZE << 12) - 1, DPL_USER);
+  c->gdt[SEG_UCODE] = SEG(STA_X|STA_R, STARTPROC, ((PROCSIZE-1) << 12), DPL_USER);
+  c->gdt[SEG_UDATA] = SEG(STA_W, STARTPROC, ((PROCSIZE-1) << 12), DPL_USER);
   lgdt(c->gdt, sizeof(c->gdt));
 }
 

--- a/vm.c
+++ b/vm.c
@@ -20,9 +20,8 @@ seginit(void)
   c = &cpus[cpuid()];
   c->gdt[SEG_KCODE] = SEG(STA_X|STA_R, 0, 0xffffffff, 0);
   c->gdt[SEG_KDATA] = SEG(STA_W, 0, 0xffffffff, 0);
-  c->gdt[SEG_UCODE] = SEG(STA_X|STA_R, STARTPROC, ((PROCSIZE) << 12) - 0x1000, DPL_USER);
-  c->gdt[SEG_UDATA] = SEG(STA_W, STARTPROC, ((PROCSIZE) << 12) - 0x1000, DPL_USER);
-
+  c->gdt[SEG_UCODE] = SEG(STA_X|STA_R, STARTPROC, (PROCSIZE << 12) - 0x1000, DPL_USER);
+  c->gdt[SEG_UDATA] = SEG(STA_W, STARTPROC, (PROCSIZE << 12) - 0x1000, DPL_USER);
   lgdt(c->gdt, sizeof(c->gdt));
 }
 
@@ -35,12 +34,6 @@ switchuvm(struct proc *p)
     panic("switchuvm: no kstack");
 
   pushcli();
-  mycpu()->gdt[SEG_UCODE] = SEG(STA_X|STA_R, p->offset, (PROCSIZE << 12)-1, DPL_USER);
-  mycpu()->gdt[SEG_UDATA] = SEG(STA_W, p->offset, (PROCSIZE << 12)-1, DPL_USER);
-  lgdt(mycpu()->gdt, sizeof(mycpu()->gdt));
-  c->gdt[SEG_UCODE] = SEG(STA_X|STA_R, STARTPROC, ((PROCSIZE-1) << 12), DPL_USER);
-  c->gdt[SEG_UDATA] = SEG(STA_W, STARTPROC, ((PROCSIZE-1) << 12), DPL_USER);
-
   mycpu()->gdt[SEG_TSS] = SEG16(STS_T32A, &mycpu()->ts,
                                 sizeof(mycpu()->ts)-1, 0);
   mycpu()->gdt[SEG_TSS].s = 0;

--- a/vm.c
+++ b/vm.c
@@ -20,8 +20,9 @@ seginit(void)
   c = &cpus[cpuid()];
   c->gdt[SEG_KCODE] = SEG(STA_X|STA_R, 0, 0xffffffff, 0);
   c->gdt[SEG_KDATA] = SEG(STA_W, 0, 0xffffffff, 0);
-  c->gdt[SEG_UCODE] = SEG(STA_X|STA_R, STARTPROC, ((PROCSIZE-1) << 12), DPL_USER);
-  c->gdt[SEG_UDATA] = SEG(STA_W, STARTPROC, ((PROCSIZE-1) << 12), DPL_USER);
+  c->gdt[SEG_UCODE] = SEG(STA_X|STA_R, STARTPROC, ((PROCSIZE) << 12) - 0x1000, DPL_USER);
+  c->gdt[SEG_UDATA] = SEG(STA_W, STARTPROC, ((PROCSIZE) << 12) - 0x1000, DPL_USER);
+
   lgdt(c->gdt, sizeof(c->gdt));
 }
 
@@ -34,6 +35,12 @@ switchuvm(struct proc *p)
     panic("switchuvm: no kstack");
 
   pushcli();
+  mycpu()->gdt[SEG_UCODE] = SEG(STA_X|STA_R, p->offset, (PROCSIZE << 12)-1, DPL_USER);
+  mycpu()->gdt[SEG_UDATA] = SEG(STA_W, p->offset, (PROCSIZE << 12)-1, DPL_USER);
+  lgdt(mycpu()->gdt, sizeof(mycpu()->gdt));
+  c->gdt[SEG_UCODE] = SEG(STA_X|STA_R, STARTPROC, ((PROCSIZE-1) << 12), DPL_USER);
+  c->gdt[SEG_UDATA] = SEG(STA_W, STARTPROC, ((PROCSIZE-1) << 12), DPL_USER);
+
   mycpu()->gdt[SEG_TSS] = SEG16(STS_T32A, &mycpu()->ts,
                                 sizeof(mycpu()->ts)-1, 0);
   mycpu()->gdt[SEG_TSS].s = 0;


### PR DESCRIPTION
changed user process segment limits(in vm.c) since we are allocating 4kB for the kernel stack, so I subtracted 4kB from the total limit of the segments instead of just subtracting 1 (or 0x1 in hex);
and changed stack pointer calculation (in proc.c), there was a mistake/confusion in regards to >>(right shift) or <<(left shift).