### PR TITLE
Prevented Unnecessary panic in log_write

### DIFF
--- a/log.c
+++ b/log.c
@@ -175,15 +175,19 @@ log_write(struct buf *b)
 {
   int i;
 
-  if (log.lh.n >= LOGSIZE || log.lh.n >= log.size - 1)
-    panic("too big a transaction");
 
   for (i = 0; i < log.lh.n; i++) {
     if (log.lh.block[i] == b->blockno)   // log absorbtion
       break;
   }
-  log.lh.block[i] = b->blockno;
+
   if (i == log.lh.n)
     log.lh.n++;
+        // prevents unnecessary panic
+
+  if (log.lh.n >= LOGSIZE || log.lh.n >= log.size - 1)
+    panic("too big a transaction");
+
+  log.lh.block[i] = b->blockno;
   b->flags |= B_DIRTY; // prevent eviction
 }


### PR DESCRIPTION
In log_write, the function panics even in the case when 1 slot is remaining, because it thinks that the value of the log header is about to increase. But writes can coalesce, and that may not change log.lh.n. Hence we can prevent a premature panic.

https://piazza.com/class/lqkhcjr4xst5cz/post/80

<img width="1020" alt="Screenshot 2024-05-05 at 8 01 41 PM" src="https://github.com/codenet/col331/assets/122673067/02232322-7f0d-434f-a6a8-486b1e50264a">

