### PR TITLE
Fix unsafe sprintf in io.c and remove dead code in mem.c

### DIFF
--- a/01/io.c
+++ b/01/io.c
@@ -10,7 +10,7 @@ int main(int argc, char *argv[]) {
     int fd = open("/tmp/file", O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
     assert(fd >= 0);
     char buffer[20];
-    sprintf(buffer, "hello world\n");
+    snprintf(buffer, sizeof(buffer), "hello world\n");
     int rc = write(fd, buffer, strlen(buffer));
     assert(rc == (strlen(buffer)));
     close(fd);

--- a/01/mem.c
+++ b/01/mem.c
@@ -18,6 +18,5 @@ int main(int argc, char *argv[]) {
 		*p = *p + 1;
 		printf("value of p: %d\n", *p);
 	}
-	return 0;
 }
 


### PR DESCRIPTION
This PR fixes two minor issues:

1. Replaces unsafe `sprintf` with bounded `snprintf` in `io.c` to avoid potential buffer overflow.
2. Removes unreachable dead code (`return 0;`) in `mem.c`, which is never executed due to an intentional infinite loop.

These changes improve code safety and cleanliness without altering program behavior.