### PR TITLE
Fix incomplete clean target in 02/Makefile

### DIFF
--- a/02/Makefile
+++ b/02/Makefile
@@ -47,4 +47,4 @@ CFLAGS=-fcf-protection=none -fno-asynchronous-unwind-tables -m32 -fno-pie -no-pi
 	objdump -d 02.o > 02.dump
 
 clean:
-	rm *.o *.s *.dump
+	rm -f *.o *.s *.dump 02.main


### PR DESCRIPTION
## Problem
The `clean` target in `02/Makefile` is incomplete and has two issues: 

1. **Missing executable removal**: The target removes intermediate files (*. o, *.s, *. dump) but doesn't remove the final executable `02.main` that is built by the `all` target
2. **No error handling**: Uses `rm` without the `-f` flag, which will cause errors if files don't exist

## Solution
This PR fixes both issues: 
- Adds `02.main` to the list of files to be removed
- Adds the `-f` flag to `rm` to prevent errors when files are missing
