### PR TITLE
Remove redundant -fno-pic flags from bootblock compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,8 +68,8 @@ xv6.img: bootblock kernel
 	dd if=kernel of=xv6.img seek=1 conv=notrunc
 
 bootblock: bootasm.S bootmain.c
-	$(CC) $(CFLAGS) -fno-pic -O -nostdinc -I. -c bootmain.c
-	$(CC) $(CFLAGS) -fno-pic -nostdinc -I. -c bootasm.S
+	$(CC) $(CFLAGS) -O -nostdinc -I. -c bootmain.c
+	$(CC) $(CFLAGS) -nostdinc -I. -c bootasm.S
 	$(LD) $(LDFLAGS) -N -e start -Ttext 0x7C00 -o bootblock.o bootasm.o bootmain.o
 	$(OBJDUMP) -S bootblock.o > bootblock.asm
 	$(OBJCOPY) -S -O binary -j .text bootblock.o bootblock


### PR DESCRIPTION
Since -fno-pic is already included in CFLAGS, there is no need to specify it again in the bootblock compilation commands for bootmain.c and bootasm.S.