### PR TITLE
Cleanup: Remove unused "end" external declaration in main.c

### DIFF
--- a/main.c
+++ b/main.c
@@ -2,8 +2,6 @@
 #include "defs.h"
 #include "x86.h"
 
-extern char end[]; // first address after kernel loaded from ELF file
-
 // Bootstrap processor starts running C code here.
 // Allocate a real stack and switch to it, first
 // doing some setup required for memory allocator to work.


### PR DESCRIPTION
This Pull Request removes the external declaration `extern char end[];` from line 5 of `main.c`.

**Rationale:**
The symbol `end` is typically provided by the linker to mark the end of the kernel's code/data sections and is used in standard xv6 implementations to initialize the memory allocator (e.g., via `kinit`). However, the current implementation of `main()` in `main.c` does not perform memory allocator initialization or reference the `end` symbol.

Consequently, this declaration is dead code. Removing it adheres to the project's goal of cleaning up unused code.

**Changes:**

* **File:** `main.c`
* **Action:** Removed `extern char end[]; // first address after kernel loaded from ELF file`