### PR TITLE
Toolchain Not Found in Macos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,10 @@ TOOLPREFIX := $(shell if i386-jos-elf-objdump -i 2>&1 | grep '^elf32-i386$$' >/d
 	then echo 'i686-elf-'; \
 	elif i386-elf-objdump -i 2>&1 | grep 'elf32-i386' >/dev/null 2>&1; \
 	then echo 'i386-elf-'; \
+	elif x86_64-elf-objdump -i 2>&1 | grep 'elf32-i386' >/dev/null 2>&1; \
+	then echo 'x86_64-elf-'; \
 	else echo "***" 1>&2; \
-	echo "*** Error: Couldn't find an i386-*-elf version of GCC/binutils." 1>&2; \
+	echo "*** Error: Couldn't find an i386-*-elf or x86_64-elf- version of GCC/binutils." 1>&2; \
 	echo "*** Is the directory with i386-jos-elf-gcc in your PATH?" 1>&2; \
 	echo "*** If your i386-*-elf toolchain is installed with a command" 1>&2; \
 	echo "*** prefix other than 'i386-jos-elf-', set your TOOLPREFIX" 1>&2; \


### PR DESCRIPTION
Several users (including myself) on Apple Silicon Macs encountered issues running make qemu due to the absence of the i386-elf toolchain. 

According to chatgpt, the commonly available "x86_64-elf-" cross-compilers on macOS support generating elf32-i386 binaries and work correctly for the current build process. Thus adding a check for "x86_64-elf-" in the "ifndef TOOLPREFIX ... endif" portion of the makefile resolved the issue.

While I am not certain whether this is the originally intended toolchain, it appears to work for the branches we have encountered up till now.

I believe this fix can save others with similar setups a significant amount of time, as I spent quite a while trying to obtain the i386-elf toolchain on modern macOS to no avail. If this change is accepted, the same update could be applied to other branches as well, and I would be happy to submit additional pull requests.