### PR TITLE
Fixed build failure on newer GCC: suppressed false -Warray-bounds in mp.c

### DIFF
--- a/mp.c
+++ b/mp.c
@@ -53,6 +53,10 @@ mpsearch(void)
   uint p;
   struct mp *mp;
 
+#if defined(__GNUC__) 
+#pragma GCC diagnostic push 
+#pragma GCC diagnostic ignored "-Warray-bounds" 
+#endif
   // bda = (uchar *) P2V(0x400);
   bda = (uchar *) 0x400;
   if((p = ((bda[0x0F]<<8)| bda[0x0E]) << 4)){
@@ -65,7 +69,9 @@ mpsearch(void)
   }
   return mpsearch1(0xF0000, 0x10000);
 }
-
+#if defined(__GNUC__) 
+#pragma GCC diagnostic pop 
+#endif
 // Search for an MP configuration table.  For now,
 // don't accept the default configurations (physaddr == 0).
 // Check for correct signature, calculate the checksum and,


### PR DESCRIPTION
On newer GCC versions, `mp.c` triggers a `-Warray-bounds` warning when reading the BIOS Data Area (BDA) in `mpsearch()`.  
Since the project builds with `-Werror`, this warning becomes a hard error and the kernel fails to compile.

This is caused by aggressive static analysis in newer GCC versions when accessing fixed physical memory addresses like `0x400`, even though this is intentional low-level code and correct at runtime.

This PR adds a scoped `#pragma GCC diagnostic push/pop` around the BDA access code and disables `-Warray-bounds` only for that section:
- Limits the suppression to the exact code that triggers the false positive
- Keeps `-Werror` intact for the rest of the codebase
- Does not change runtime behavior
- Preserves backward compatibility with older compilers, while improving portability
