### PR TITLE
Use discovered ioapicaddr (in mp.c) instead to default address

### DIFF
--- a/ioapic.c
+++ b/ioapic.c
@@ -6,7 +6,7 @@
 #include "defs.h"
 #include "traps.h"
 
-#define IOAPIC  0xFEC00000   // Default physical address of IO APIC
+// #define IOAPIC  0xFEC00000   // No longer needed as we are using discovered ioapic addr instead of default one
 
 #define REG_ID     0x00  // Register index: ID
 #define REG_VER    0x01  // Register index: version
@@ -23,6 +23,7 @@
 #define INT_LOGICAL    0x00000800  // Destination is CPU id (vs APIC ID)
 
 volatile struct ioapic *ioapic;
+extern uint* ioapicaddr;
 
 // IO APIC MMIO structure: write reg, then read or write data.
 struct ioapic {
@@ -50,7 +51,7 @@ ioapicinit(void)
 {
   int i, id, maxintr;
 
-  ioapic = (volatile struct ioapic*)IOAPIC;
+  ioapic = (volatile struct ioapic*)ioapicaddr;
   maxintr = (ioapicread(REG_VER) >> 16) & 0xFF;
   id = ioapicread(REG_ID) >> 24;
   if(id != ioapicid)

--- a/mp.c
+++ b/mp.c
@@ -14,6 +14,7 @@
 struct cpu cpus[NCPU];
 int ncpu;
 uchar ioapicid;
+uint* ioapicaddr;
 
 static uchar
 sum(uchar *addr, int len)
@@ -118,6 +119,7 @@ mpinit(void)
     case MPIOAPIC:
       ioapic = (struct mpioapic*)p;
       ioapicid = ioapic->apicno;
+      ioapicaddr = ioapic->addr;
       p += sizeof(struct mpioapic);
       continue;
     case MPBUS:


### PR DESCRIPTION
This pull request updates the way the IOAPIC physical address is determined and used throughout the codebase. Instead of relying on a hardcoded default address, the IOAPIC address is now dynamically discovered and stored, improving flexibility and correctness on systems where the IOAPIC is not at the default location.

**IOAPIC address handling improvements:**

* Removed the hardcoded `#define IOAPIC 0xFEC00000` and updated comments to reflect that the IOAPIC address is now discovered instead of assumed.
* Introduced a new external variable `ioapicaddr` to hold the discovered IOAPIC address, and updated its declaration in `ioapic.c`.
* Changed the initialization in `ioapicinit(void)` to use the discovered `ioapicaddr` instead of the default address.

**MP (multiprocessor) configuration changes:**

* Added a global variable `ioapicaddr` in `mp.c` to store the IOAPIC address.
* Set `ioapicaddr` to the value found in the MP table during `mpinit(void)`, ensuring the correct address is used system-wide.

Note :
This change needs to be propagated to all the branches.
