### PR TITLE
Use discovered iopic addr instead of default value

### DIFF
--- a/ioapic.c
+++ b/ioapic.c
@@ -20,7 +20,7 @@
 #define INT_DISABLED   0x00010000  // Interrupt disabled
 
 volatile struct ioapic *ioapic;
-extern uint ioapicaddr;
+extern uint* ioapicaddr;
 
 // IO APIC MMIO structure: write reg, then read or write data.
 struct ioapic {

--- a/ioapic.c
+++ b/ioapic.c
@@ -6,7 +6,7 @@
 #include "defs.h"
 #include "traps.h"
 
-#define IOAPIC  0xFEC00000   // Default physical address of IO APIC
+// #define IOAPIC  0xFEC00000   // No longer needed as we are using discovered ioapic addr
 
 #define REG_ID     0x00  // Register index: ID
 #define REG_VER    0x01  // Register index: version
@@ -20,6 +20,7 @@
 #define INT_DISABLED   0x00010000  // Interrupt disabled
 
 volatile struct ioapic *ioapic;
+extern uint ioapicaddr;
 
 // IO APIC MMIO structure: write reg, then read or write data.
 struct ioapic {
@@ -47,7 +48,7 @@ ioapicinit(void)
 {
   int i, id, maxintr;
 
-  ioapic = (volatile struct ioapic*)IOAPIC;
+  ioapic = (volatile struct ioapic*)ioapicaddr;
   maxintr = (ioapicread(REG_VER) >> 16) & 0xFF;
   id = ioapicread(REG_ID) >> 24;
   if(id != ioapicid)

--- a/mp.c
+++ b/mp.c
@@ -14,6 +14,7 @@
 struct cpu cpus[NCPU];
 int ncpu;
 uchar ioapicid;
+uint ioapicaddr;
 
 static uchar
 sum(uchar *addr, int len)
@@ -118,6 +119,7 @@ mpinit(void)
     case MPIOAPIC:
       ioapic = (struct mpioapic*)p;
       ioapicid = ioapic->apicno;
+      ioapicaddr = ioapic->addr;
       p += sizeof(struct mpioapic);
       continue;
     case MPBUS:

--- a/mp.c
+++ b/mp.c
@@ -14,7 +14,7 @@
 struct cpu cpus[NCPU];
 int ncpu;
 uchar ioapicid;
-uint ioapicaddr;
+uint* ioapicaddr;
 
 static uchar
 sum(uchar *addr, int len)


### PR DESCRIPTION
This pull request updates how the IO APIC address is handled in the codebase, switching from a hardcoded default address to using the address discovered during system initialization. The changes improve flexibility and correctness by ensuring the IO APIC is mapped using its actual hardware address.

**IO APIC address handling:**

* Removed the hardcoded `IOAPIC` address definition in `ioapic.c` since the address is now dynamically discovered.
* Added a new global variable `ioapicaddr` to store the discovered IO APIC address in both `ioapic.c` and `mp.c`. [[1]](diffhunk://#diff-a3b7ee6ce2f002ab0e57d8d7abc91fdea5ec9c2ab6986de0b78c22893d2bad86R23) [[2]](diffhunk://#diff-e587550e304004a044577a45659d5c59564ad83a65aef91beb4e8c89be83c29dR17)
* Updated the `ioapicinit` function to use `ioapicaddr` instead of the hardcoded address for mapping the IO APIC.
* Set `ioapicaddr` to the discovered address in the MP table parsing logic in `mpinit` within `mp.c`.