### PR TITLE
Fix_main_p6_ide

### DIFF
--- a/main.c
+++ b/main.c
@@ -9,7 +9,7 @@ extern char end[]; // first address after kernel loaded from ELF file
 static inline void
 welcome(void) {
   struct buf *b0 = bread(1, 0);
-  for(int i=0; i <= BSIZE; i++)
+  for(int i=0; i < BSIZE; i++)
     consputc(b0->data[i]);
   
   struct buf *b1 = bread(1, 1);


### PR DESCRIPTION
Since BSIZE is 512 defined in fs.h we should iterate from 0 to 511 not till 512 as this would be out of order access for data array in the buf struct