### PR TITLE
Fix missing return statement in 02/02.func.c

### DIFF
--- a/02/02.func.c
+++ b/02/02.func.c
@@ -6,5 +6,5 @@ int bar() {
 int func() {
 	int x = 11;
 	bar();
-	foo(x, 23);
+	return foo(x, 23);
 }


### PR DESCRIPTION
Added return statement to func() which is declared as returning int but was missing a return value.