### PR TITLE
Corrected Size in Inode in p7-mkfs.md

### DIFF
--- a/p7-mkfs.md
+++ b/p7-mkfs.md
@@ -44,7 +44,7 @@ map blocks.
 This is the 64 bytes of the second inode representing the "/" directory. First
 two bytes is `0100` which is 1 in little-endian. This means that this file is a
 directory (`type` is `T_DIR`).  `major` and `minor` are both zero, `nlink` is 1.
-`size` is `0002 0000` which is basically `0x0000 0200` = 8192 bytes. The first
+`size` is `0002 0000` which is basically `0x0000 0200` = 512 bytes. The first
 address is `1d00 0000` which is basically `0x1d` = 29 (the first data block).
 
 The next 64 bytes represent the "welcome.txt" file.


### PR DESCRIPTION
The size of the / Directory is 0x0000 0200 = 16 * 16 * 2 = 512 bytes. Corrected 8192 -> 512.

This change can be applied to all future branches as well. I'd be happy to make those pull requests if this gets accepted.