### PR TITLE
Use exact ceiling division for nbitmap and ninodeblcoks

### DIFF
--- a/mkfs.c
+++ b/mkfs.c
@@ -20,8 +20,8 @@
 // Disk layout:
 // [ boot block | sb block | log | inode blocks | free bit map | data blocks ]
 
-int nbitmap = FSSIZE/(BSIZE*8) + 1;
-int ninodeblocks = NINODES / IPB + 1;
+int nbitmap = (FSSIZE + BSIZE*8 - 1) / (BSIZE*8);  // exact
+int ninodeblocks = (NINODES + IPB - 1) / IPB;       // exact
 int nlog = LOGSIZE;
 int nmeta;    // Number of meta blocks (boot, sb, nlog, inode, bitmap)
 int nblocks;  // Number of data blocks


### PR DESCRIPTION
Previously, `nbitmap` and `ninodeblocks` were calculated using `+ 1` which 
always allocated an extra block even when unnecessary. This wasted up to 2 
blocks (1KB) per filesystem.

Changed to proper integer ceiling division: `(n + divisor - 1) / divisor`
