### PR TITLE
Fix incorrect root directory size rounding in mkfs.c

### DIFF
--- a/mkfs.c
+++ b/mkfs.c
@@ -158,7 +158,7 @@ main(int argc, char *argv[])
   // fix size of root inode dir
   rinode(rootino, &din);
   off = xint(din.size);
-  off = ((off/BSIZE) + 1) * BSIZE;
+  off = ((off + BSIZE - 1) / BSIZE) * BSIZE;
   din.size = xint(off);
   winode(rootino, &din);
 


### PR DESCRIPTION
In mkfs.c, after populating the root directory entries, the following code adjusts the directory size:

off = ((off/BSIZE) + 1) * BSIZE;
din.size = xint(off);

This logic always increases the size by one full block, even when off is already a multiple of BSIZE.
The size should only be rounded up if it is not already aligned.