### PR TITLE
Fix file descriptor usage in io.c

### DIFF
--- a/05/io.c
+++ b/05/io.c
@@ -21,8 +21,8 @@ int main(int argc, char *argv[]) {
 	sprintf(buffer, "COL331");
 
 	int fd2 = open("/tmp/file", O_RDWR);
-	lseek(fd, 6, SEEK_SET);
-	rc = write(fd, buffer, strlen(buffer));
+	lseek(fd2, 6, SEEK_SET);
+	rc = write(fd2, buffer, strlen(buffer));
 	assert(rc == (strlen(buffer)));
 
 	int fd3 = open("/tmp/file", O_WRONLY | O_APPEND);

--- a/05/io.c
+++ b/05/io.c
@@ -21,11 +21,13 @@ int main(int argc, char *argv[]) {
 	sprintf(buffer, "COL331");
 
 	int fd2 = open("/tmp/file", O_RDWR);
+	assert(fd2 >= 0);
 	lseek(fd2, 6, SEEK_SET);
 	rc = write(fd2, buffer, strlen(buffer));
 	assert(rc == (strlen(buffer)));
 
 	int fd3 = open("/tmp/file", O_WRONLY | O_APPEND);
+	assert(fd3 >= 0);
 	write(fd3, "!\n", 2);
 	close(fd3);
 


### PR DESCRIPTION
Fixed bug in io.c, instead of seeking and writing to fd which was closed earlier, we now correctly write to fd2