### PR TITLE
Remove duplicate code

### DIFF
--- a/param.h
+++ b/param.h
@@ -3,8 +3,6 @@
 #define NINODE       50  // maximum number of active i-nodes
 #define ROOTDEV       1  // device number of file system root disk
 #define MAXOPBLOCKS  10  // max # of blocks any FS op writes
-#define NINODE       50  // maximum number of active i-nodes
-#define ROOTDEV       1  // device number of file system root disk
 #define LOGSIZE      0  // max data blocks in on-disk log
 #define NBUF         (MAXOPBLOCKS*3)  // size of disk block cache
 #define FSSIZE       1000  // size of file system in blocks


### PR DESCRIPTION
This PR removes the duplicate definition of NINODE  and ROOTDEV in the file param.h