### PR TITLE
fixed out of bounds access of buffer cache

### DIFF
--- a/main.c
+++ b/main.c
@@ -9,7 +9,7 @@ extern char end[]; // first address after kernel loaded from ELF file
 static inline void
 welcome(void) {
   struct buf *b0 = bread(1, 0);
-  for(int i=0; i <= BSIZE; i++)
+  for(int i=0; i < BSIZE; i++)
     consputc(b0->data[i]);
   
   struct buf *b1 = bread(1, 1);


### PR DESCRIPTION
The data field in struct buf (the buffer cache) is only of size 512, but here we access the 513th element. As it is the flag field of the next buffer cache (b1) , it tries to print ascii value of 0 or 1 which luckily happens to be null .So we are not able to see any errors printed or any other character. However this is an error, fixed this.