### PR TITLE
Fix inode memory leak in welcome() function

### DIFF
--- a/defs.h
+++ b/defs.h
@@ -24,6 +24,7 @@ void            iread(struct inode*);
 struct inode*   iget(uint dev, uint inum);
 int             readi(struct inode*, char*, uint, uint);
 void            stati(struct inode*, struct stat*);
+void            irelse(struct inode*);
 int             namecmp(const char*, const char*);
 struct inode*   namei(char*);
 struct inode*   nameiparent(char*, char*);

--- a/fs.c
+++ b/fs.c
@@ -65,7 +65,7 @@ iinit(int dev)
           sb.bmapstart);
 }
 
-static void
+void
 irelse(struct inode *ip)
 {
   ip->ref--;

--- a/main.c
+++ b/main.c
@@ -21,6 +21,8 @@ welcome(void) {
   int n = readi(wtxt, greet, 0, st.size);
   cprintf("Read %d bytes from welcome.txt\n", n);
   cprintf("%s\n", greet);
+
+  irelse(wtxt);
 }
 
 // Bootstrap processor starts running C code here.


### PR DESCRIPTION
The inode for welcome.txt is acquired by welcome.txt for printing it to the console, but never released hence overloading the inode cache. 

This PR fixes the memory leak by:
1. Calling `irelse(wtxt)` at the end of `welcome()` to properly release the inode reference
2. Making `irelse()` publicly accessible by removing the `static` modifier in `fs.c`
3. Adding `irelse()` declaration to `defs.h` to expose it as part of the public API

