### PR TITLE
Fix size value representation in p7-mkfs.md

### DIFF
--- a/p7-mkfs.md
+++ b/p7-mkfs.md
@@ -49,7 +49,7 @@ We might later see that `nlink` can be greater than 1 when we create symbolic
 links to the same file. Notice that `.` and `..` do not count towards `nlink`; 
 otherwise a directory may never get deleted.
 
-`size` is `0000 0200` which is basically `0x0002 0000` = 8192 bytes. The first
+`size` is `0002 0000` which is basically `0x0000 0200` = 512 bytes. The first
 address is `1d00 0000` which is basically `0x1d` = 29 (the first data block).
 
 The next 64 bytes represent the "welcome.txt" file.


### PR DESCRIPTION
I have made two changes.

First, instead of "size is 0000 0200, which is basically 0x0002 0000", it should be "size is 0002 0000, which is basically 0x0000 0200" as written in the p7-mkfs.md of the branch p7-mkfs. This was correct in branch p7-mkfs, but is wrong in p8-read-fs.

The second change is that instead of 8192 bytes, it will be 512 bytes, as pointed out by reesabh-k in https://github.com/codenet/col331/pull/113.