### PR TITLE
Comment line related to locks removed

### DIFF
--- a/fs.c
+++ b/fs.c
@@ -323,7 +323,6 @@ itrunc(struct inode *ip)
 }
 
 // Copy stat information from inode.
-// Caller must hold ip->lock.
 void
 stati(struct inode *ip, struct stat *st)
 {


### PR DESCRIPTION
The comment claimed to have the caller hold the lock but the lock is not yet implemented