### PR TITLE
Removed the condition for nlink

### DIFF
--- a/fs.c
+++ b/fs.c
@@ -342,7 +342,7 @@ readi(struct inode *ip, char *dst, uint off, uint n)
   uint tot, m;
   struct buf *bp;
 
-  if(off > ip->size || off + n < off || ip->nlink < 1)
+  if(off > ip->size || off + n < off)
     return -1;
   if(off + n > ip->size)
     n = ip->size - off;


### PR DESCRIPTION
Rejecting reads when nlink == 0 incorrectly prevents legitimate access to such files.
A file can be unlinked (nlink == 0)
But still remain accessible through open file descriptors
readi() must not depend on nlink.
It should only validate:
Offset bounds
Overflow
Thus I feel
The ip->nlink < 1 condition must be removed.