### PR TITLE
Remove redundant comment from trap function making it consistent with p8-read-fs.

### DIFF
--- a/trap.c
+++ b/trap.c
@@ -26,7 +26,6 @@ idtinit(void)
   lidt(idt, sizeof(idt));
 }
 
-//PAGEBREAK: 41
 void
 trap(struct trapframe *tf)
 {


### PR DESCRIPTION
Removed redundant comments that have been removed correctly in p8-read-fs.