### PR TITLE
Refactor log absorption handling in log.c

### DIFF
--- a/log.c
+++ b/log.c
@@ -180,10 +180,9 @@ log_write(struct buf *b)
 
   for (i = 0; i < log.lh.n; i++) {
     if (log.lh.block[i] == b->blockno)   // log absorbtion
-      break;
+      return;
   }
   log.lh.block[i] = b->blockno;
-  if (i == log.lh.n)
-    log.lh.n++;
+  log.lh.n++;
   b->flags |= B_DIRTY; // prevent eviction
 }


### PR DESCRIPTION
This pull request refactors log_write to eliminate redundant operations during log absorption. While the previous implementation was logically sound, it unnecessarily overwrote the block number even when a match was found and relied on a trailing conditional check to increment the transaction size. The new approach uses an early return as soon as a block match is identified, skipping redundant assignments and streamlining the control flow. This makes the code semantically clearer—distinguishing between an existing entry and a new one—while reducing the instruction count for blocks already present in the current transaction.