### PR TITLE
Remove fileinit declaration from defs.h

### DIFF
--- a/defs.h
+++ b/defs.h
@@ -21,7 +21,6 @@ void            consputc(int);
 struct file*    filealloc(void);
 void            fileclose(struct file*);
 struct file*    filedup(struct file*);
-void            fileinit(void);
 int             fileread(struct file*, char*, int n);
 int             filestat(struct file*, struct stat*);
 int             filewrite(struct file*, char*, int n);


### PR DESCRIPTION
Drop the obsolete void fileinit(void) prototype from defs.h. This keeps the header in sync with the implementation (the function was removed/renamed) and avoids an unused or duplicate declaration.