### PR TITLE
Remove picenable prototype from defs.h

### DIFF
--- a/defs.h
+++ b/defs.h
@@ -77,7 +77,6 @@ extern int      ismp;
 void            mpinit(void);
 
 // picirq.c
-void            picenable(int);
 void            picinit(void);
 
 // proc.c


### PR DESCRIPTION
This function is declared but never defined anywhere. In xv6-public, picenable() exists in picirq.c. Here picirqi.c only has picinit(). The declaration is dead code.