### PR TITLE
Fixed directory linking between root directory and foo folder

### DIFF
--- a/main.c
+++ b/main.c
@@ -20,7 +20,7 @@ welcome(void) {
     foodir = ialloc(ROOTDEV, T_DIR);
     iread(foodir);
     dirlink(foodir, ".", foodir->inum);
-    dirlink(foodir, "..", foodir->inum);
+    dirlink(foodir, "..", root->inum);
     dirlink(root, "foo", foodir->inum);
   }
   


### PR DESCRIPTION
Fixed directory linking between root directory and foo folder:
"/foo/.." now links to "/" and not "/foo" 