### PR TITLE
Unused variable in struct log

### DIFF
--- a/log.c
+++ b/log.c
@@ -37,7 +37,6 @@ struct logheader {
 struct log {
   int start;
   int size;
-  int committing;  // in commit(), please wait.
   int dev;
   struct logheader lh;
 };


### PR DESCRIPTION
Removed variable 'committing' from struct log. Not used anywhere in the codebase in any branch.