### PR TITLE
Fix memory leak: Release foo inode pointer in welcome()

### DIFF
--- a/main.c
+++ b/main.c
@@ -39,7 +39,7 @@ welcome(void) {
   if(!isdirempty(foo)) {
     panic("/foo should be empty");
   }
-
+  iput(foo);
   if((gtxt = open("/foo/hello.txt", O_RDONLY)) != 0) {
     panic("Could open /foo/hello.txt after unlinking");
   }


### PR DESCRIPTION
Fix memory leak by releasing foo inode pointer after isdirempty check in welcome()