### PR TITLE
Remove rtcdate and cmostime declarations

### DIFF
--- a/defs.h
+++ b/defs.h
@@ -1,5 +1,4 @@
 struct buf;
-struct rtcdate;
 struct superblock;
 struct inode;
 struct stat;
@@ -58,7 +57,6 @@ extern uchar    ioapicid;
 void            ioapicinit(void);
 
 // lapic.c
-void            cmostime(struct rtcdate *r);
 int             lapicid(void);
 extern volatile uint*    lapic;
 void            lapiceoi(void);


### PR DESCRIPTION
struct rtcdate is never defined anywhere, and cmostime() is never implemented. In xv6-public, cmostime is defined in lapic.c and uses struct rtcdate from date.h, but neither exists in this branch.