### PR TITLE
Remove lapicstartap dead declaration

### DIFF
--- a/defs.h
+++ b/defs.h
@@ -63,7 +63,6 @@ int             lapicid(void);
 extern volatile uint*    lapic;
 void            lapiceoi(void);
 void            lapicinit(void);
-void            lapicstartap(uchar, uint);
 void            microdelay(int);
 
 // log.c


### PR DESCRIPTION
This function is declared but never defined in the codebase.