### PR TITLE
Fix buffer leak in bmap() indirect lookup

### DIFF
--- a/fs.c
+++ b/fs.c
@@ -146,7 +146,9 @@ bmap(struct inode *ip, uint bn)
     // Load indirect block
     bp = bread(ip->dev, ip->addrs[NDIRECT]);
     uint *a = (uint*)bp->data;
-    return a[bn];
+    uint addr = a[bn];
+    brelse(bp);
+    return addr;
   }
 
   panic("bmap: out of range");

--- a/mp.c
+++ b/mp.c
@@ -54,10 +54,6 @@ mpsearch(void)
   struct mp *mp;
 
   // bda = (uchar *) P2V(0x400);
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Warray-bounds"
-#pragma GCC diagnostic ignored "-Wstringop-overflow"
-#pragma GCC diagnostic ignored "-Wstringop-overread"
   bda = (uchar *) 0x400;
   if((p = ((bda[0x0F]<<8)| bda[0x0E]) << 4)){
     if((mp = mpsearch1(p, 1024)))
@@ -67,8 +63,6 @@ mpsearch(void)
     if((mp = mpsearch1(p-1024, 1024)))
       return mp;
   }
-#pragma GCC diagnostic pop
-
   return mpsearch1(0xF0000, 0x10000);
 }
 

--- a/mp.c
+++ b/mp.c
@@ -54,6 +54,10 @@ mpsearch(void)
   struct mp *mp;
 
   // bda = (uchar *) P2V(0x400);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#pragma GCC diagnostic ignored "-Wstringop-overread"
   bda = (uchar *) 0x400;
   if((p = ((bda[0x0F]<<8)| bda[0x0E]) << 4)){
     if((mp = mpsearch1(p, 1024)))
@@ -63,6 +67,8 @@ mpsearch(void)
     if((mp = mpsearch1(p-1024, 1024)))
       return mp;
   }
+#pragma GCC diagnostic pop
+
   return mpsearch1(0xF0000, 0x10000);
 }
 


### PR DESCRIPTION
bmap() reads the indirect block using bread() but returned the address without calling brelse(), leaving the buffer referenced. This change stores the needed block address, calls brelse(bp), and then returns the stored value to avoid leaking buffer cache entries.