### PR TITLE
main.c: fix parent directory link for foodir in welcome function

### DIFF
--- a/main.c
+++ b/main.c
@@ -20,7 +20,7 @@ welcome(void) {
     foodir = ialloc(ROOTDEV, T_DIR);
     iread(foodir);
     dirlink(foodir, ".", foodir->inum);
-    dirlink(foodir, "..", foodir->inum);
+    dirlink(foodir, "..", root->inum);
     dirlink(root, "foo", foodir->inum);
   }
   


### PR DESCRIPTION
The directory creation code for /foo incorrectly linked ".." to the directory itself. This broke parent traversal (e.g., /foo/.. would resolve to /foo). Update ".." to point to the parent inode (root).