### PR TITLE
Bug fix in p9 fs.c namex()

### DIFF
--- a/fs.c
+++ b/fs.c
@@ -286,7 +286,7 @@ namex(char *path, int nameiparent, char *name)
     }
     if(nameiparent && *path == '\0'){
       // Stop one level early.
-      irelse(ip);
+      
       return ip;
     }
     if((next = dirlookup(ip, name, 0)) == 0){


### PR DESCRIPTION
To make the ref of return inode consistent.Returned inode should have ref>0. 
Earlier, the ref of returned inode was zero due to irelse(),which is deleted.