### PR TITLE
Fix incorrect `".."` link in `main.c` and add missing `nlink` updates for directory and hard link creation

### DIFF
--- a/main.c
+++ b/main.c
@@ -19,8 +19,13 @@ welcome(void) {
     cprintf("/foo not found. Creating!\n");
     foodir = ialloc(ROOTDEV, T_DIR);
     iread(foodir);
+    // Initialize directory link counts
+    foodir->nlink = 2;       // "." and parent's reference
+    iupdate(foodir);
+    root->nlink++;       // new subdirectory increases parent's link count
+    iupdate(root);
     dirlink(foodir, ".", foodir->inum);
-    dirlink(foodir, "..", foodir->inum);
+    dirlink(foodir, "..",root->inum);
     dirlink(root, "foo", foodir->inum);
   }
   
@@ -30,6 +35,9 @@ welcome(void) {
     cprintf("/foo/greet.txt not found. Creating!\n");
     struct inode* wtxt_orig = namei("/welcome.txt");
     dirlink(foodir, "greet.txt", wtxt_orig->inum);
+    // Increment link count of target inode
+    wtxt_orig->nlink++;
+    iupdate(wtxt_orig);
     wtxt=namei("/foo/greet.txt");
   }
 


### PR DESCRIPTION
Fix two correctness issues in `main.c` related to directory and hard link creation.

1. In `main.c`, the `".."` entry for the newly created `/foo` directory was incorrectly set to `foodir->inum` (self-reference). This caused `/foo/..` to resolve to `/foo` instead of `/`.
   Updated the code so `".."` now correctly points to `root->inum`.

2. Link counts (`nlink`) were not updated when:

   * Creating the `/foo` directory.
   * Creating the hard link `/foo/greet.txt` to `/welcome.txt`.

   Added the following fixes:

   * Set `foodir->nlink = 2` to account for `"."` and the parent reference.
   * Increment `root->nlink` when adding `/foo` as a subdirectory.
   * Increment `wtxt_orig->nlink` when linking `/foo/greet.txt` to `/welcome.txt`.
   * Persist all updated inodes using `iupdate()`.

These changes restore correct directory parent semantics and maintain proper Unix link count invariants.
