### PR TITLE
Fix: GCC array-bounds compilation error in mp.c

### DIFF
--- a/mp.c
+++ b/mp.c
@@ -46,6 +46,8 @@ mpsearch1(uint a, int len)
 // 1) in the first KB of the EBDA;
 // 2) in the last KB of system base memory;
 // 3) in the BIOS ROM between 0xE0000 and 0xFFFFF.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
 static struct mp*
 mpsearch(void)
 {
@@ -65,6 +67,7 @@ mpsearch(void)
   }
   return mpsearch1(0xF0000, 0x10000);
 }
+#pragma GCC diagnostic pop
 
 // Search for an MP configuration table.  For now,
 // don't accept the default configurations (physaddr == 0).


### PR DESCRIPTION
# Build Fix Tracker

## PR: Fix GCC array-bounds compilation error in mp.c

**Environment:**
- Building on WSL (Windows Subsystem for Linux)

**Issue:**
- Compilation fails with `-Werror=array-bounds` errors in `mp.c` (as present in Makefile)
- Error occurs in `mpsearch()` function at lines 58 and 62
- GCC treats BIOS Data Area (BDA) access at address 0x400 as out-of-bounds array access

**Error Messages:**
```
mp.c:58:16: error: array subscript 0 is outside array bounds of 'uchar[0]'
mp.c:58:31: error: array subscript 0 is outside array bounds of 'uchar[0]'
mp.c:62:14: error: array subscript 0 is outside array bounds of 'uchar[0]'
mp.c:62:28: error: array subscript 0 is outside array bounds of 'uchar[0]'
```

**Root Cause:**
- The code intentionally accesses low memory addresses (BIOS Data Area at 0x400) for MP initialization
- Modern GCC's strict bounds checking flags this as potentially unsafe

**Solution:**
Added GCC diagnostic pragmas around the `mpsearch()` function to suppress the specific warning:

```c
#pragma GCC diagnostic push
#pragma GCC diagnostic ignored "-Warray-bounds"
static struct mp*
mpsearch(void)
{
  // ... function body ...
}
#pragma GCC diagnostic pop
```

**Location:** [mp.c](mp.c#L44-L67) - wrap the `mpsearch()` function

**Alternative:** Remove `-Werror` flag from Makefile (not recommended - loses strict checking)

---

## Testing

**Build Test:**
After applying the pragma directives around `mpsearch()` function:

```bash
$ make qemu
```

**Result:** ✓ Build successful
- No array-bounds errors
- xv6 boots successfully in QEMU

**Verification:**
- Compilation completes without errors
- Boot loader loads correctly (451 bytes, max 510)
- Welcome message displays in QEMU

The pragmas successfully suppress the false-positive array-bounds warning while maintaining strict error checking for the rest of the codebase.
