### PR TITLE
fixed .. linking to parent

### DIFF
--- a/main.c
+++ b/main.c
@@ -19,8 +19,11 @@ welcome(void) {
     cprintf("/foo not found. Creating!\n");
     foodir = ialloc(ROOTDEV, T_DIR);
     iread(foodir);
+    char name[DIRSIZ];
+    struct inode* parent = nameiparent("/foo", name);
+    iread(parent);
     dirlink(foodir, ".", foodir->inum);
-    dirlink(foodir, "..", foodir->inum);
+    dirlink(foodir, "..", parent->inum);
     dirlink(root, "foo", foodir->inum);
   }
   


### PR DESCRIPTION
Currently in the main file, when creating a new directory inside the root, the .. is linked to the same directory as it was done for the root.

But in general, this is not the norm and it should ideally point to the parent directory or the root directory in this case. Instead of hard coding that it should be root which can also be done, we can find the parent and then consequently link .. to the parent