### PR TITLE
Fix parent directory link in foo directory creation

### DIFF
--- a/main.c
+++ b/main.c
@@ -20,7 +20,7 @@ welcome(void) {
     foodir = ialloc(ROOTDEV, T_DIR);
     iread(foodir);
     dirlink(foodir, ".", foodir->inum);
-    dirlink(foodir, "..", foodir->inum);
+    dirlink(foodir, "..", root->inum);
     dirlink(root, "foo", foodir->inum);
   }
   


### PR DESCRIPTION
When creating the /foo directory, the parent directory link (..) was incorrectly pointing to the directory itself (foodir->inum) instead of pointing to its actual parent directory (the root directory).
Changed line 23 to correctly set the .. link to root->inum, ensuring the parent directory link properly points to the root directory.