### PR TITLE
Modified log_write for improved transaction handling

### DIFF
--- a/log.c
+++ b/log.c
@@ -174,14 +174,13 @@ void
 log_write(struct buf *b)
 {
   int i;
-
-  if (log.lh.n >= LOGSIZE || log.lh.n >= log.size - 1)
-    panic("too big a transaction");
-
+  // check for log absorption before panicking
   for (i = 0; i < log.lh.n; i++) {
     if (log.lh.block[i] == b->blockno)   // log absorbtion
       break;
   }
+  if (i==log.lh.n && (log.lh.n >= LOGSIZE || log.lh.n >= log.size - 1))
+    panic("too big a transaction");
   log.lh.block[i] = b->blockno;
   if (i == log.lh.n)
     log.lh.n++;


### PR DESCRIPTION
Refactor log_write function to check for log absorption before panicking on transaction size. No need to panic if log is full but we are not adding a new block to the log