### PR TITLE
Remove duplicate definitions in param.h

### DIFF
--- a/p14-segments.md
+++ b/p14-segments.md
@@ -63,7 +63,7 @@ little-endian.
 1. 2 least significant bytes represent two least significant bytes of limit:
 `0xffff`.
 2. Base address is split across the descriptor. Patching them together, we get
-based address of the segment as `0x00000000`.
+base address of the segment as `0x00000000`.
 3. The remaining thing is `0x9a 0xcf`. From this, we get:
 0xa
 * Type: 1010. From Table 3.1, means that this is a code segment which can be read

--- a/param.h
+++ b/param.h
@@ -4,9 +4,7 @@
 #define ROOTDEV       1  // device number of file system root disk
 #define MAXOPBLOCKS  10  // max # of blocks any FS op writes
 #define NFILE       100  // open files per system
-#define NINODE       50  // maximum number of active i-nodes
 #define NDEV         10  // maximum major device number
-#define ROOTDEV       1  // device number of file system root disk
 #define LOGSIZE      (MAXOPBLOCKS*3)  // max data blocks in on-disk log
 #define NBUF         (MAXOPBLOCKS*3)  // size of disk block cache
 #define FSSIZE       1000  // size of file system in blocks


### PR DESCRIPTION
Removed duplicate definitions for NINODE and ROOTDEV.