### PR TITLE
Remove unused <sys/stat.h> header

### DIFF
--- a/01/common.h
+++ b/01/common.h
@@ -2,6 +2,7 @@
 #define __common_h__
 
 #include <sys/time.h>
+
 #include <assert.h>
 
 double GetTime() {

--- a/01/common.h
+++ b/01/common.h
@@ -2,7 +2,6 @@
 #define __common_h__
 
 #include <sys/time.h>
-#include <sys/stat.h>
 #include <assert.h>
 
 double GetTime() {

--- a/01/common.h
+++ b/01/common.h
@@ -2,7 +2,6 @@
 #define __common_h__
 
 #include <sys/time.h>
-
 #include <assert.h>
 
 double GetTime() {


### PR DESCRIPTION
The header <sys/stat.h> was included in common.h but is not used
anywhere in the file.

Removing unused headers reduces unnecessary dependencies and
improves code clarity.

The project compiles successfully after this change.