### PR TITLE
Removed unnecessary references to common.h

### DIFF
--- a/01/Makefile
+++ b/01/Makefile
@@ -9,9 +9,9 @@ cpu: cpu.c common.h
 mem: mem.c common.h
 	gcc -o mem mem.c -Wall -Wl,-no_pie
 
-threads: threads.c common.h common_threads.h
+threads: threads.c common_threads.h
 	gcc -o threads threads.c -Wall -pthread
 
-io: io.c common.h
+io: io.c 
 	gcc -o io io.c -Wall
 

--- a/01/threads.c
+++ b/01/threads.c
@@ -1,6 +1,5 @@
 #include <stdio.h>
 #include <stdlib.h>
-#include "common.h"
 #include "common_threads.h"
 
 volatile int counter = 0; 


### PR DESCRIPTION
Removed unused `common.h` references.

* `threads.c` does not use `common.h`, so the include was removed and the Makefile updated.
* `io.c` does not reference `common.h`; corrected the Makefile dependency.

No functional impact. Build verified successfully.
