### PR TITLE
Fix: sys_write: use argptr instead of argstr for buffer argument

### DIFF
--- a/sysfile.c
+++ b/sysfile.c
@@ -70,7 +70,7 @@ sys_write(void)
   int n;
   char *p;
 
-  if((argfd(0, 0, &f) < 0) || (argstr(1, &p)) < 0 || (argint(2, &n)) < 0) {
+  if((argfd(0, 0, &f) < 0) || (argint(2, &n)) < 0|| (argptr(1, &p, n)) < 0 ) {
     return -1;
   }
   return filewrite(f, p, n);


### PR DESCRIPTION
The `sys_write` function was using `argstr` to fetch the write buffer, which only works for null-terminated strings. `write() `operates on raw byte buffers of explicit length n, so `argptr` should be used instead and also will be consistent with how `sys_read` does it also in x86. 
Also reordered argument fetching so n is fetched before `argptr` can use it for bounds checking.