### PR TITLE
Fix misleading comment for consoleinit

### DIFF
--- a/main.c
+++ b/main.c
@@ -34,7 +34,7 @@ main(void)
   lapicinit();     // interrupt controller
   picinit();       // disable pic
   ioapicinit();    // another interrupt controller
-  consoleinit();   // console hardware
+  consoleinit();   // register console device handlers
   uartinit();      // serial port
   ideinit();       // disk 
   tvinit();        // trap vectors


### PR DESCRIPTION
This PR updates the comment next to `consoleinit()` in `main.c`.

The earlier comment, `// console hardware`, is misleading because `consoleinit()` in this patch is used to set up the console's file-interface behavior, not to directly initialize hardware.

This change only improves the accuracy of the comment and does not modify functionality.