### PR TITLE
Fix stack pointer offset in allocproc()

### DIFF
--- a/proc.c
+++ b/proc.c
@@ -55,7 +55,7 @@ found:
   p->state = EMBRYO;
   p->pid = nextpid++;
 
-  sp = (char*)(STARTPROC + (PROCSIZE>>12));
+  sp = (char*)(STARTPROC + (PROCSIZE<<12));
 
   // Leave room for trap frame.
   sp -= sizeof *p->tf;


### PR DESCRIPTION
This PR fixes the stack pointer calculation in `allocproc()`.

`PROCSIZE` is defined in units of 4 KB pages, so converting it to a byte offset requires shifting left by 12. The current code uses `>> 12`, which evaluates to 0 for `PROCSIZE = 0x100`, causing `sp` to be initialized at `STARTPROC` instead of at the top of the process region.

This change replaces:

`STARTPROC + (PROCSIZE >> 12)`

with:

`STARTPROC + (PROCSIZE << 12)`