### PR TITLE
P21: Implementation of Hardware Spinlocks and Basic Concurrency

### DIFF
--- a/bio.c
+++ b/bio.c
@@ -23,8 +23,10 @@
 #include "param.h"
 #include "fs.h"
 #include "buf.h"
+#include "spinlock.h"
 
 struct {
+  struct spinlock lock;
   struct buf buf[NBUF];
 
   // Linked list of all buffers, through prev/next.
@@ -36,6 +38,7 @@ void
 binit(void)
 {
   struct buf *b;
+  initlock(&bcache.lock, "bcache");
 
   // Create linked list of buffers
   bcache.head.prev = &bcache.head;
@@ -56,10 +59,12 @@ bget(uint dev, uint blockno)
 {
   struct buf *b;
 
+  acquire(&bcache.lock);
   // Is the block already cached?
   for(b = bcache.head.next; b != &bcache.head; b = b->next){
     if(b->dev == dev && b->blockno == blockno){
       b->refcnt++;
+      release(&bcache.lock);
       return b;
     }
   }
@@ -73,6 +78,7 @@ bget(uint dev, uint blockno)
       b->blockno = blockno;
       b->flags = 0;
       b->refcnt = 1;
+      release(&bcache.lock);
       return b;
     }
   }
@@ -106,6 +112,7 @@ bwrite(struct buf *b)
 void
 brelse(struct buf *b)
 {
+  acquire(&bcache.lock);
   b->refcnt--;
   if (b->refcnt == 0) {
     // no one is waiting for it.
@@ -116,4 +123,5 @@ brelse(struct buf *b)
     bcache.head.next->prev = b;
     bcache.head.next = b;
   }
+  release(&bcache.lock);
 }

--- a/console.c
+++ b/console.c
@@ -9,9 +9,13 @@
 #include "traps.h"
 #include "fs.h"
 #include "file.h"
+#include "spinlock.h"
 
 static int panicked = 0;
-
+struct {
+  struct spinlock lock;
+  int locking;
+} cons;
 static void
 printint(int xx, int base, int sign)
 {
@@ -48,6 +52,8 @@ cprintf(char *fmt, ...)
   if (fmt == 0)
     // panic("null fmt");
     return;
+  if(cons.locking)           
+    acquire(&cons.lock);     
 
   argp = (uint*)(void*)(&fmt + 1);
   for(i = 0; (c = fmt[i] & 0xff) != 0; i++){
@@ -82,6 +88,8 @@ cprintf(char *fmt, ...)
       break;
     }
   }
+  if(cons.locking)           
+    release(&cons.lock);     
 }
 
 void
@@ -101,6 +109,7 @@ panic(char *s)
   uint pcs[10];
 
   cli();
+  cons.locking = 0; // force release of the console for the panic message
   cprintf("lapicid %d: panic: ", lapicid());
   cprintf(s);
   cprintf("\n");
@@ -214,6 +223,8 @@ consolewrite(struct inode *ip, char *buf, int n)
 void
 consoleinit(void)
 {
+  initlock(&cons.lock, "console"); 
+  cons.locking = 1;                
   devsw[CONSOLE].write = consolewrite;
   devsw[CONSOLE].read = consoleread;
 }

--- a/defs.h
+++ b/defs.h
@@ -99,11 +99,20 @@ struct proc*    myproc();
 void            scheduler(void) __attribute__((noreturn));
 void            procdump(void);
 void            yield(void);
+void             forkret(void);
 
 // spinlock.c
 void            getcallerpcs(void*, uint*);
 void            pushcli(void);
 void            popcli(void);
+
+struct spinlock; 
+void            getcallerpcs(void*, uint*);
+void            pushcli(void);
+void            popcli(void);
+void            initlock(struct spinlock*, char*);
+void            acquire(struct spinlock*);
+void            release(struct spinlock*);
 
 // string.c
 int             memcmp(const void*, const void*, uint);

--- a/file.c
+++ b/file.c
@@ -9,24 +9,33 @@
 #include "file.h"
 #include "stat.h"
 #include "fcntl.h"
+#include "spinlock.h"
 
 struct devsw devsw[NDEV];
 struct {
   struct file file[NFILE];
+  struct spinlock lock;
 } ftable;
 
+void
+fileinit(void)
+{
+  initlock(&ftable.lock, "ftable");
+}
 // Allocate a file structure.
 struct file*
 filealloc(void)
 {
   struct file *f;
-
+  acquire(&ftable.lock);
   for(f = ftable.file; f < ftable.file + NFILE; f++){
     if(f->ref == 0){
       f->ref = 1;
+      release(&ftable.lock);
       return f;
     }
   }
+  release(&ftable.lock);
   return 0;
 }
 
@@ -34,9 +43,11 @@ filealloc(void)
 struct file*
 filedup(struct file *f)
 {
+  acquire(&ftable.lock);
   if(f->ref < 1)
     panic("filedup");
   f->ref++;
+  release(&ftable.lock);
   return f;
 }
 
@@ -46,14 +57,17 @@ fileclose(struct file *f)
 {
   struct file ff;
 
+  acquire(&ftable.lock);
   if(f->ref < 1)
     panic("fileclose");
   if(--f->ref > 0){
+    release(&ftable.lock);
     return;
   }
   ff = *f;
   f->ref = 0;
   f->type = FD_NONE;
+  release(&ftable.lock);
 
   if(ff.type == FD_INODE){
     begin_op();

--- a/fs.c
+++ b/fs.c
@@ -18,6 +18,7 @@
 #include "fs.h"
 #include "buf.h"
 #include "file.h"
+#include "spinlock.h"
 
 #define min(a, b) ((a) < (b) ? (a) : (b))
 static void itrunc(struct inode*);
@@ -110,12 +111,14 @@ bfree(int dev, uint b)
 //
 
 struct {
+  struct spinlock lock; 
   struct inode inode[NINODE];
 } icache;
 
 void
 iinit(int dev)
 {
+  initlock(&icache.lock, "icache");
   readsb(dev, &sb);
   cprintf("sb: size %d nblocks %d ninodes %d nlog %d logstart %d\
  inodestart %d bmap start %d\n", sb.size, sb.nblocks,
@@ -156,17 +159,26 @@ ialloc(uint dev, short type)
 void
 iput(struct inode *ip)
 {
+  acquire(&icache.lock); // (Protect the ref check)
+  
   if(ip->valid && ip->nlink == 0){
     int r = ip->ref;
     if(r == 1){
       // inode has no links and no other references: truncate and free.
+      
+      release(&icache.lock); // Drop lock before disk I/O!
+      
       itrunc(ip);
       ip->type = 0;
       iupdate(ip);
       ip->valid = 0;
+      
+      acquire(&icache.lock); // Re-acquire lock to safely decrement ref
     }
   }
+  
   ip->ref--;
+  release(&icache.lock); // (Final release)
 }
 
 // Copy a modified in-memory inode to disk.
@@ -198,11 +210,14 @@ iget(uint dev, uint inum)
 {
   struct inode *ip, *empty;
 
+  acquire(&icache.lock);
+
   // Is the inode already cached?
   empty = 0;
   for(ip = &icache.inode[0]; ip < &icache.inode[NINODE]; ip++){
     if(ip->ref > 0 && ip->dev == dev && ip->inum == inum){
       ip->ref++;
+      release(&icache.lock);
       return ip;
     }
     if(empty == 0 && ip->ref == 0)    // Remember empty slot.
@@ -218,6 +233,8 @@ iget(uint dev, uint inum)
   ip->inum = inum;
   ip->ref = 1;
   ip->valid = 0;
+
+  release(&icache.lock);
 
   return ip;
 }

--- a/ide.c
+++ b/ide.c
@@ -9,6 +9,7 @@
 #include "traps.h"
 #include "fs.h"
 #include "buf.h"
+#include "spinlock.h"
 
 #define SECTOR_SIZE   512
 #define IDE_BSY       0x80
@@ -25,6 +26,7 @@
 // idequeue->qnext points to the next buf to be processed.
 // You must hold idelock while manipulating queue.
 
+struct spinlock idelock;     
 static struct buf *idequeue;
 
 static int havedisk1;
@@ -47,7 +49,7 @@ ideinit(void)
 {
   int i;
 
-  // initlock(&idelock, "ide");
+  initlock(&idelock, "ide");
   ioapicenable(IRQ_IDE, ncpu - 1);
   idewait(0);
 
@@ -100,8 +102,11 @@ ideintr(void)
 {
   struct buf *b;
 
+  acquire(&idelock);
+
   // First queued buffer is the active request.
   if((b = idequeue) == 0){
+    release(&idelock);
     return;
   }
   idequeue = b->qnext;
@@ -116,6 +121,8 @@ ideintr(void)
   // Start disk on next buf in queue.
   if(idequeue != 0)
     idestart(idequeue);
+
+  release(&idelock);
 }
 
 // Sync buf with disk.
@@ -125,6 +132,8 @@ void
 iderw(struct buf *b)
 {
   struct buf **pp;
+
+  acquire(&idelock);
 
   if((b->flags & (B_VALID|B_DIRTY)) == B_VALID)
     panic("iderw: nothing to do");
@@ -140,6 +149,7 @@ iderw(struct buf *b)
   // Start disk if necessary.
   if(idequeue == b)
     idestart(b);
+  release(&idelock);
 
   // Wait for request to finish.
   while((b->flags & (B_VALID|B_DIRTY)) != B_VALID)

--- a/kalloc.c
+++ b/kalloc.c
@@ -7,6 +7,7 @@
 #include "param.h"
 #include "memlayout.h"
 #include "mmu.h"
+#include "spinlock.h"
 
 void freerange(void *vstart, void *vend);
 extern char end[]; // first address after kernel loaded from ELF file
@@ -16,14 +17,17 @@ struct run {
   struct run *next;
 };
 
+
 struct {
+  struct spinlock lock; 
   struct run *freelist;
 } kmem;
 
 void
 kinit(void *vstart, void *vend)
 {
-  freerange(vstart, vend);
+  initlock(&kmem.lock, "kmem"); 
+  freerange(vstart, vend);      // (freerange calls kfree, so the lock must exist!)
 }
 
 void
@@ -51,8 +55,10 @@ kfree(char *v)
   memset(v, 1, PGSIZE);
 
   r = (struct run*)v;
+  acquire(&kmem.lock);
   r->next = kmem.freelist;
   kmem.freelist = r;
+  release(&kmem.lock);
 }
 
 // Allocate one PGSIZE page of physical memory.
@@ -63,9 +69,11 @@ kalloc(void)
 {
   struct run *r;
 
+  acquire(&kmem.lock);
   r = kmem.freelist;
   if(r)
     kmem.freelist = r->next;
+  release(&kmem.lock);
   return (char*)r;
 }
 

--- a/log.c
+++ b/log.c
@@ -3,6 +3,7 @@
 #include "param.h"
 #include "fs.h"
 #include "buf.h"
+#include "spinlock.h"
 
 // Simple logging that allows concurrent FS system calls.
 //
@@ -35,6 +36,7 @@ struct logheader {
 };
 
 struct log {
+  struct spinlock lock;
   int start;
   int size;
   int committing;  // in commit(), please wait.
@@ -51,6 +53,8 @@ initlog(int dev)
 {
   if (sizeof(struct logheader) >= BSIZE)
     panic("initlog: too big logheader");
+
+  initlock(&log.lock, "log");
 
   struct superblock sb;
   readsb(dev, &sb);
@@ -175,6 +179,8 @@ log_write(struct buf *b)
 {
   int i;
 
+  acquire(&log.lock);
+
   if (log.lh.n >= LOGSIZE || log.lh.n >= log.size - 1)
     panic("too big a transaction");
 
@@ -185,5 +191,7 @@ log_write(struct buf *b)
   log.lh.block[i] = b->blockno;
   if (i == log.lh.n)
     log.lh.n++;
+
+  release(&log.lock);
   b->flags |= B_DIRTY; // prevent eviction
 }

--- a/main.c
+++ b/main.c
@@ -27,6 +27,7 @@ main(void)
   ideinit();       // disk 
   tvinit();        // trap vectors
   binit();         // buffer cache
+  fileinit();      // file table
   idtinit();       // load idt register
   sti();           // enable interrupts
   iinit(ROOTDEV);  // Read superblock to start reading inodes

--- a/proc.c
+++ b/proc.c
@@ -5,8 +5,10 @@
 #include "mmu.h"
 #include "x86.h"
 #include "proc.h"
+#include "spinlock.h"
 
 struct {
+  struct spinlock lock;
   struct proc proc[NPROC];
 } ptable;
 
@@ -45,15 +47,17 @@ allocproc(void)
   struct proc *p;
   char *sp;
 
+  acquire(&ptable.lock);
   for(p = ptable.proc; p < &ptable.proc[NPROC]; p++)
     if(p->state == UNUSED)
       goto found;
-
+  release(&ptable.lock); // (if no slots found)
   return 0;
 
 found:
   p->state = EMBRYO;
   p->pid = nextpid++;
+  release(&ptable.lock); // (safe to release now that state is EMBRYO)
 
   if((p->offset = kalloc()) == 0){
     p->state = UNUSED;
@@ -70,10 +74,17 @@ found:
   sp -= sizeof *p->tf;
   p->tf = (struct trapframe*)sp;
 
+  // Set up new context to start executing at forkret,
+  // which returns to trapret.
+  sp -= 4;                             
+  *(uint*)sp = (uint)trapret;          
+
   sp -= sizeof *p->context;
   p->context = (struct context*)sp;
   memset(p->context, 0, sizeof *p->context);
-  p->context->eip = (uint)trapret;
+  // p->context->eip = (uint)trapret;
+  
+  p->context->eip = (uint)forkret;
 
   return p;
 }
@@ -82,6 +93,8 @@ found:
 void
 pinit(void)
 {
+  initlock(&ptable.lock, "ptable");
+  
   struct proc *p;
   extern char _binary_initcode_start[], _binary_initcode_size[];
 
@@ -124,6 +137,7 @@ scheduler(void)
     // Enable interrupts on this processor.
     sti();
 
+    acquire(&ptable.lock); // (lock before scanning processes)
     // Loop over process table looking for process to run.
     for(p = ptable.proc; p < &ptable.proc[NPROC]; p++){
       if(p->state != RUNNABLE)
@@ -136,6 +150,7 @@ scheduler(void)
       switchuvm(p);
       swtch(&(c->scheduler), p->context);
     }
+    release(&ptable.lock); // (release when done scanning)
   }
 }
 
@@ -166,8 +181,17 @@ sched(void)
 void
 yield(void)
 {
+  acquire(&ptable.lock);
   myproc()->state = RUNNABLE;
   sched();
+  release(&ptable.lock);
+}
+
+void
+forkret(void)
+{
+  // Release the lock held by the scheduler
+  release(&ptable.lock);
 }
 
 void
@@ -181,7 +205,7 @@ procdump(void)
   };
   struct proc *p;
   char *state;
-
+  acquire(&ptable.lock);
   for(p = ptable.proc; p < &ptable.proc[NPROC]; p++){
     if(p->state == UNUSED)
       continue;
@@ -192,4 +216,5 @@ procdump(void)
     cprintf("%d %s %s", p->pid, state, p->name);
     cprintf("\n");
   }
+  release(&ptable.lock);
 }

--- a/spinlock.c
+++ b/spinlock.c
@@ -5,6 +5,7 @@
 #include "defs.h"
 #include "mmu.h"
 #include "proc.h"
+#include "spinlock.h"
 
 // Record the current call stack in pcs[] by following the %ebp chain.
 void
@@ -51,4 +52,30 @@ popcli(void)
     panic("popcli");
   if(mycpu()->ncli == 0 && mycpu()->intena)
     sti();
+}
+
+
+
+void
+initlock(struct spinlock *lk, char *name)
+{
+  lk->name = name;
+  lk->locked = 0;
+}
+
+// Acquire the lock.
+// Disables interrupts to ensure no context switches happen.
+void
+acquire(struct spinlock *lk)
+{
+  pushcli(); // disable interrupts to avoid race conditions
+  lk->locked = 1;
+}
+
+// Release the lock.
+void
+release(struct spinlock *lk)
+{
+  lk->locked = 0;
+  popcli();  // re-enable interrupts if appropriate
 }

--- a/spinlock.h
+++ b/spinlock.h
@@ -1,0 +1,6 @@
+// Mutual exclusion lock.
+#include "types.h"
+struct spinlock {
+  uint locked;       // Is the lock held?
+  char *name;        // Name of lock.
+};

--- a/trap.c
+++ b/trap.c
@@ -5,17 +5,19 @@
 #include "proc.h"
 #include "x86.h"
 #include "traps.h"
+#include "spinlock.h"
 
 // Interrupt descriptor table (shared by all CPUs).
 struct gatedesc idt[256];
 extern uint vectors[];  // in vectors.S: array of 256 entry pointers
+struct spinlock tickslock;
 uint ticks;
 
 void
 tvinit(void)
 {
   int i;
-
+  initlock(&tickslock, "time");
   for(i = 0; i < 256; i++)
     SETGATE(idt[i], 0, SEG_KCODE<<3, vectors[i], 0);
   SETGATE(idt[T_SYSCALL], 1, SEG_KCODE<<3, vectors[T_SYSCALL], DPL_USER);
@@ -38,7 +40,9 @@ trap(struct trapframe *tf)
 
   switch(tf->trapno){
   case T_IRQ0 + IRQ_TIMER:
+    acquire(&tickslock);
     ticks++;
+    release(&tickslock);
     lapiceoi();
     break;
   case T_IRQ0 + IRQ_IDE:


### PR DESCRIPTION
_Note: I have targeted the p20-exec branch for this PR because the p21 branch does not yet exist in the upstream repo. Once the p21 branch is created, the base branch of this PR can be changed to p21 for merging._

### Overview
This PR implements the P21 requirements by introducing basic concurrency controls. I have added hardware spinlocks and protected all core OS data structures to match the `xv6-public` standard, preventing single-processor interrupt race conditions.

### Key Implementations:
* **Core Lock Mechanism:** Created `spinlock.h` and implemented `acquire`/`release` logic utilizing the existing `pushcli` and `popcli` interrupt controls.
* **Protecting Core OS Components:** Carefully applied locks across the kernel, specifically avoiding deadlocks during disk I/O:
  * `kalloc.c`: Protected the physical memory allocator (`kmem.lock`).
  * `proc.c`: Protected the process table (`ptable.lock`) and implemented `forkret` to properly release the scheduler lock for newly allocated processes.
  * `bio.c`: Protected the block buffer cache (`bcache.lock`) across all return paths.
  * `file.c`: Protected the open file table (`ftable.lock`).
  * `fs.c`: Protected the inode cache (`icache.lock`), ensuring the lock is temporarily released before disk I/O in `iput` to prevent deadlocks during `itrunc`.
  * `ide.c`: Protected the disk request queue (`idelock`) while safely keeping the wait loop lock-free.
  * `console.c`, `trap.c`, `log.c`: Secured the console (`cons.lock`), timer ticks (`tickslock`), and log headers (`log.lock` via `log_write`).

*(Note: `fileread`, `filewrite`, and `consoleread` are intentionally left lock-free as they rely on Sleep Locks, which are planned for P22).*