### PR TITLE
Add missing locks in console.c and proc.c 

### DIFF
--- a/console.c
+++ b/console.c
@@ -145,7 +145,8 @@ void
 consoleintr(int (*getc)(void))
 {
   int c, doprocdump=0;
-
+  
+  acquire(&cons.lock);
   while((c = getc()) >= 0){
     switch(c){
     case C('P'):  // Process listing.
@@ -178,6 +179,8 @@ consoleintr(int (*getc)(void))
       break;
     }
   }
+  release(&cons.lock);
+
   if(doprocdump) {
     procdump();
   }
@@ -191,6 +194,7 @@ consoleread(struct inode *ip, char *dst, int n)
   int c;
 
   target = n;
+  acquire(&cons.lock);
   while(n > 0){
     while(input.r == input.w);
     c = input.buf[input.r++ % INPUT_BUF];
@@ -207,7 +211,7 @@ consoleread(struct inode *ip, char *dst, int n)
     if(c == '\n')
       break;
   }
-
+  release(&cons.lock);
   return target - n;
 }
 
@@ -215,8 +219,10 @@ int
 consolewrite(struct inode *ip, char *buf, int n)
 {
   int i;
+  acquire(&cons.lock);
   for(i = 0; i < n; i++)
     consputc(buf[i] & 0xff);
+  release(&cons.lock);
   return n;
 }
 

--- a/console.c
+++ b/console.c
@@ -145,7 +145,7 @@ void
 consoleintr(int (*getc)(void))
 {
   int c, doprocdump=0;
-  
+
   acquire(&cons.lock);
   while((c = getc()) >= 0){
     switch(c){
@@ -194,7 +194,6 @@ consoleread(struct inode *ip, char *dst, int n)
   int c;
 
   target = n;
-  acquire(&cons.lock);
   while(n > 0){
     while(input.r == input.w);
     c = input.buf[input.r++ % INPUT_BUF];
@@ -211,7 +210,7 @@ consoleread(struct inode *ip, char *dst, int n)
     if(c == '\n')
       break;
   }
-  release(&cons.lock);
+
   return target - n;
 }
 

--- a/proc.c
+++ b/proc.c
@@ -60,14 +60,18 @@ found:
   release(&ptable.lock); // (safe to release now that state is EMBRYO)
 
   if((p->offset = kalloc()) == 0){
+    acquire(&ptable.lock);
     p->state = UNUSED;
+    release(&ptable.lock);
     return 0;
   }
   p->sz = PGSIZE;
 
   // kstack lives on a different segment
   if((p->kstack = kalloc()) == 0){
+    acquire(&ptable.lock);
     p->state = UNUSED;
+    release(&ptable.lock);
     return 0;
   }
 


### PR DESCRIPTION
This PR adds the missing locks to console.c and proc.c, as mentioned in #214 :

Changes made in console.c:
- Added locking in consoleintr() around shared console input buffer state
- Ensured consoleintr() releases the console lock before calling procdump()
- Added locking in consolewrite() to serialize console output

Changes made in proc.c:
- Fixed allocproc() failure paths so p->state = UNUSED is updated under ptable.lock

Notes: 
- I did not add cons.lock around the waiting loop in consoleread(). If consoleread() holds cons.lock while waiting for input.r != input.w, then consoleintr() cannot acquire the same lock to insert new input into the buffer, thus creating a deadlock.
- All files have not been checked thoroughly for missing locks in this PR, so they may need to be added in subsequent PRs