### PR TITLE
Remove dead code from p15: param.h

### DIFF
--- a/param.h
+++ b/param.h
@@ -6,9 +6,7 @@
 #define MAXOPBLOCKS  10  // max # of blocks any FS op writes
 #define NOFILE       16  // open files per process
 #define NFILE       100  // open files per system
-#define NINODE       50  // maximum number of active i-nodes
 #define NDEV         10  // maximum major device number
-#define ROOTDEV       1  // device number of file system root disk
 #define LOGSIZE      (MAXOPBLOCKS*3)  // max data blocks in on-disk log
 #define NBUF         (MAXOPBLOCKS*3)  // size of disk block cache
 #define FSSIZE       1000  // size of file system in blocks


### PR DESCRIPTION
Removed duplicate definitions of NINODE and ROOTDEV.