### PR TITLE
Fix string redundancy in halt() and correct grammar/comments across P2

### DIFF
--- a/console.c
+++ b/console.c
@@ -33,7 +33,7 @@ printint(int xx, int base, int sign)
     consputc(buf[i]);
 }
 
-// Print to the console. only understands %d, %x, %p, %s.
+// Print to the console. Only understands %d, %x, %p, %s.
 void
 cprintf(char *fmt, ...)
 {

--- a/main.c
+++ b/main.c
@@ -5,7 +5,7 @@
 int
 halt(void)
 {
-  cprintf("Bye COL%d!\n\0", 331);
+  cprintf("Bye COL%d!\n", 331);
   outw(0x604, 0x2000);
   // For older versions of QEMU, 
   outw(0xB004, 0x2000);

--- a/p2-print.md
+++ b/p2-print.md
@@ -1,4 +1,4 @@
-Self study the diff:
+Self-study the diff:
 
 `git diff p1-booting`
 

--- a/uart.c
+++ b/uart.c
@@ -17,7 +17,7 @@ uartinit(void)
   // Turn off the FIFO
   outb(COM1+2, 0);
 
-  // 9600 baud, 8 data bits, 1 stop bit, parity off.
+  // Set 9600 baud (115200/9600), 8 data bits, 1 stop bit, parity off.
   outb(COM1+3, 0x80);    // Unlock divisor
   outb(COM1+0, 115200/9600);
   outb(COM1+1, 0);


### PR DESCRIPTION
**Summary**
This PR resolves a C string literal redundancy, fixes grammatical errors in documentation and comments, and cleans up the P2 codebase.

**Specific Fixes:**
* **String Redundancy (`main.c`):** Removed the explicit `\0` from the format string in `halt()` (`cprintf("Bye COL%d!\n\0", 331);`). The C compiler automatically null-terminates string literals, making the explicit escape sequence redundant and causing an unnecessary double-null in `.rodata`.
* **Grammar (`p2-print.md`):** Hyphenated "Self-study" to correct compound phrasing.
* **Grammar (`console.c`):** Fixed capitalization in the `cprintf` documentation comment (`Only understands...`).
* **Comment Clarity (`uart.c`):** Clarified the baud rate calculation comment to reflect the `115200/9600` divisor logic used in `uartinit()`.