### PR TITLE
Fixed typo in log absorption comment

### DIFF
--- a/log.c
+++ b/log.c
@@ -179,7 +179,7 @@ log_write(struct buf *b)
     panic("too big a transaction");
 
   for (i = 0; i < log.lh.n; i++) {
-    if (log.lh.block[i] == b->blockno)   // log absorbtion
+    if (log.lh.block[i] == b->blockno)   // log absorption
       break;
   }
   log.lh.block[i] = b->blockno;


### PR DESCRIPTION
Fixed typo in log absorption comment in log.c