### PR TITLE
correct stack pointer

### DIFF
--- a/proc.c
+++ b/proc.c
@@ -90,7 +90,7 @@ pinit(void)
   p->tf->ss = p->tf->ds;
 
   p->tf->eflags = FL_IF;
-  p->tf->esp = PGSIZE;
+  p->tf->esp = PROCSIZE<<12;  // top of process memory
   p->tf->eip = 0;  // beginning of initcode.S
 
   safestrcpy(p->name, "initcode", sizeof(p->name));


### PR DESCRIPTION
as per the diagram discussed in class the stack pointer should be at the top of the address space of the process, earlier it was set to PGSIZE, which is not correct as paging has not beed done yet. 