### PR TITLE
 Replace PROCSIZE >> 12 with PROCSIZE << 12 in proc.c

### DIFF
--- a/proc.c
+++ b/proc.c
@@ -55,7 +55,7 @@ found:
   p->state = EMBRYO;
   p->pid = nextpid++;
 
-  sp = (char*)(STARTPROC + (PROCSIZE>>12));
+  sp = (char*)(STARTPROC + (PROCSIZE<<12));
 
   // Allocate kernel stack.
   p->kstack = sp - KSTACKSIZE;


### PR DESCRIPTION
I think PROCSIZE is defined in 4KB-page units, so it must be shifted left to convert to bytes. 