### PR TITLE
Discord Github PR Notification

### DIFF
--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -1,7 +1,7 @@
 name: Discord PR Notification
 
 on:
-  pull_request:
+  pull_request_target:
     # Trigger the workflow when a pull request is closed (merged or not merged) // Shall Filter in scripts/notify.py  
     types: [closed] 
   workflow_dispatch: 

--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -1,0 +1,36 @@
+name: Discord PR Notification
+
+on:
+  pull_request:
+    # Trigger the workflow when a pull request is closed (merged or not merged) // Shall Filter in scripts/notify.py  
+    types: [closed] 
+  workflow_dispatch: 
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4 # Load the repo to access the scripts/notify.py
+
+      - name: Install Python-Dependencies
+        run:  pip install requests
+
+      - name: Notify Discord by running the script
+        run:  python scripts/notify.py
+        env:
+          # Setup Webhook
+          WEBHOOK: ${{ secrets.DISCORD }}
+
+          # Event type
+          EVENT_NAME: ${{ github.event_name }}
+
+          # PR data
+          PR_TITLE:      ${{ github.event.pull_request.title }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_URL:        ${{ github.event.pull_request.html_url }}
+          PR_AUTHOR:     ${{ github.event.pull_request.user.login }}
+          PR_STATE:      ${{ github.event.pull_request.state }}
+          PR_MERGED:     ${{ github.event.pull_request.merged }}
+          TARGET_BRANCH: ${{ github.event.pull_request.base.ref }}
+          

--- a/scripts/notfiy.py
+++ b/scripts/notfiy.py
@@ -1,0 +1,92 @@
+import os
+import requests
+
+def send_notification(web_hook, pay_load):
+    resp = requests.post(web_hook, json=pay_load)
+    if resp.status_code != 204:
+        print(f"Failed to send notification.\n Status code: {resp.status_code} \n Response: {resp.text}")
+        exit(1)
+
+
+def get_discord_payload_v0(title, url, author, branch):
+    payload = {
+        "embeds": [
+            {
+                "title": "PR Merged",
+                "url": url,
+                "color": 3066993,  # green in decimal (0x2ecc71 in hex)
+                "fields": [
+                    {
+                        "name": "Title",
+                        "value": title,
+                        "inline": False
+                    },
+                    {
+                        "name": "Author",
+                        "value": author,
+                        "inline": True
+                    },
+                    {
+                        "name": "Target Branch",
+                        "value": branch,
+                        "inline": True
+                    }
+                ],
+                "footer": {
+                    "text": f"Branch: {branch}"
+                }
+            }
+        ]
+    }
+    
+    return
+    
+def get_discord_payload_v1(title, url, author, branch, number):
+    payload = {
+        "embeds": [
+            {
+                "title": f"PR #{number}: {title}",
+                "url": url,
+                "color": 3066993,  
+                "description": f"Merged into **{branch}**",
+                "fields": [
+                    {
+                        "name": "Author",
+                        "value": author,
+                        "inline": True
+                    },
+                    {
+                        "name": "Branch",
+                        "value": branch,
+                        "inline": True
+                    }
+                ],
+                "footer": {
+                    "text": "GitHub PR Notification"
+                }
+            }
+        ]
+    }
+    return payload
+
+event = os.environ.get("EVENT_NAME")
+web_hook = os.environ["WEB_HOOK"] # Discord Webhook URL presented as an environment variable
+
+if event == "pull_request_target":
+    merged = (os.environ.get("PR_MERGED") == "true")
+    
+    # Only act notify if the pull request is merged
+    if not merged:
+        print("Pull request is not merged. No notification will be sent.")
+        exit(0)
+        
+    pr_title  = os.environ.get("PR_TITLE")
+    pr_url    = os.environ.get("PR_URL")
+    pr_author = os.environ.get("PR_AUTHOR")
+    pr_target_branch = os.environ.get("TARGET_BRANCH")
+    pr_number = os.environ.get("PR_NUMBER")
+    
+    payload = get_discord_payload_v1(pr_title, pr_url, pr_author,
+                                     pr_target_branch,pr_number)
+    
+    send_notification(web_hook, payload)


### PR DESCRIPTION
## Add Discord Notifications for PR Merges

### Summary

This PR introduces a GitHub Actions workflow and a lightweight Python script to send notifications to Discord when pull requests are merged.

### Motivation

The repository contains multiple target branches (`p1-*`, `p2-*`, …), and PRs may target any of them. Maintaining separate workflows across all branches would be difficult and error-prone.
This change centralizes automation in a single place and provides visibility into merge activity via Discord.

---

### Key Design Choices

#### 1. Use of `pull_request_target`

* The workflow is triggered using:

  ```yaml
  pull_request_target:
    types: [closed]
  ```
* This ensures:

  * The workflow is always loaded from the **default branch (`main`)**
  * No need to duplicate `.github/workflows` across all `pX-*` branches

#### 2. Filter only merged PRs

* The `closed` event includes both merged and non-merged PRs
* Filtering is handled in `scripts/notify.py`:

  * Only merged PRs generate notifications

#### 3. Python-based notification logic

* All formatting and routing logic is implemented in `scripts/notify.py`
* This avoids complex YAML scripting and makes future extensions easier

#### 4. Discord Webhook Integration

* Uses repository secret:

  ```
  DISCORD_WEBHOOK
  ```
* Sends structured messages (embed format) to the configured Discord channel (`#pr-merges`)

---

### Features (Initial Scope)

* Notify when a PR is merged
* Include:

  * PR title
  * PR number
  * Author
  * Target branch
  * Direct link to PR
* Clean embed-based formatting for readability

---

### Files Added

```text
.github/workflows/discord.yml   # Workflow definition
scripts/notify.py              # Notification logic
```

---

### Testing

* Tested via push events on a personal repository
* Verified:

  * Webhook delivery
  * Embed formatting
  * Environment variable handling

---

### Future Improvements

* Notifications for:

  * PR comments
  * PR reviews
* Label-based routing (e.g., errata vs development)
* Multiple Discord channels
* Improved formatting (icons, richer embeds)

---

### Notes

* No existing functionality is modified
* Safe usage of `pull_request_target` (no execution of untrusted PR code)
* Minimal, incremental rollout for easier review

---

### Expected Outcome

Once merged, all future PR merges (to any `pX-*` branch) will automatically trigger a Discord notification without requiring additional configuration.
