### PR TITLE
syscall: apply curproc offset in argptr (p19)

### DIFF
--- a/syscall.c
+++ b/syscall.c
@@ -66,7 +66,7 @@ argptr(int n, char **pp, int size)
     return -1;
   if(size < 0 || (uint)i >= curproc->sz || (uint)i+size > curproc->sz)
     return -1;
-  *pp = (char*)i;
+  *pp = (char*)(i + curproc->offset);
   return 0;
 }
 


### PR DESCRIPTION
In argptr function, returning an unadjusted pointer can make syscalls dereference the wrong address. fetchint() / fetchstr() already add curproc->offset.