### PR TITLE
Rectify kernel stack size calc

### DIFF
--- a/proc.c
+++ b/proc.c
@@ -55,7 +55,7 @@ found:
   p->state = EMBRYO;
   p->pid = nextpid++;
 
-  sp = (char*)(STARTPROC + (PROCSIZE>>12));
+  sp = (char*)(STARTPROC + (PROCSIZE<<12));
 
   // Allocate kernel stack.
   p->kstack = sp - KSTACKSIZE;

--- a/vm.c
+++ b/vm.c
@@ -20,8 +20,8 @@ seginit(void)
   c = &cpus[cpuid()];
   c->gdt[SEG_KCODE] = SEG(STA_X|STA_R, 0, 0xffffffff, 0);
   c->gdt[SEG_KDATA] = SEG(STA_W, 0, 0xffffffff, 0);
-  c->gdt[SEG_UCODE] = SEG(STA_X|STA_R, STARTPROC, (PROCSIZE << 12) - 1, DPL_USER);
-  c->gdt[SEG_UDATA] = SEG(STA_W, STARTPROC, (PROCSIZE << 12) - 1, DPL_USER);
+  c->gdt[SEG_UCODE] = SEG(STA_X|STA_R, STARTPROC, (PROCSIZE - 1) << 12, DPL_USER);
+  c->gdt[SEG_UDATA] = SEG(STA_W, STARTPROC, (PROCSIZE - 1) << 12, DPL_USER);
   lgdt(c->gdt, sizeof(c->gdt));
 }
 


### PR DESCRIPTION
Since PROCSIZE is in multiple of 4KB, segment limit should be (PROCSIZE - 1)<<12 instead of (PROCSIZE<<12)-1 
<img width="1272" height="684" alt="Screenshot 2026-03-20 234507" src="https://github.com/user-attachments/assets/fef03e16-0bc4-49bf-bf83-9ed223c96879" />


For sp calculation we should use << operator instead of >> operator

