### PR TITLE
Added newpart label filtering for Discord Notifications

### DIFF
--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -28,9 +28,10 @@ jobs:
 
           # PR data
           PR_TITLE:      ${{ github.event.pull_request.title }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER:     ${{ github.event.pull_request.number }}
           PR_URL:        ${{ github.event.pull_request.html_url }}
           PR_AUTHOR:     ${{ github.event.pull_request.user.login }}
+          PR_LABELS:     ${{ toJson(github.event.pull_request.labels) }}
           PR_STATE:      ${{ github.event.pull_request.state }}
           PR_MERGED:     ${{ github.event.pull_request.merged }}
           TARGET_BRANCH: ${{ github.event.pull_request.base.ref }}

--- a/scripts/notify.py
+++ b/scripts/notify.py
@@ -1,5 +1,6 @@
 import os
 import requests
+import json
 
 def send_notification(web_hook, pay_load):
     resp = requests.post(web_hook, json=pay_load)
@@ -39,7 +40,7 @@ def get_discord_payload_v0(title, url, author, branch):
         ]
     }
     
-    return
+    return payload
     
 def get_discord_payload_v1(title, url, author, branch, number):
     payload = {
@@ -71,15 +72,20 @@ def get_discord_payload_v1(title, url, author, branch, number):
 
 event = os.environ.get("EVENT_NAME")
 web_hook = os.environ["WEBHOOK"] # Discord Webhook URL presented as an environment variable
+NEW_PART = "newpart"
 
 if event == "pull_request_target":
     merged = (os.environ.get("PR_MERGED") == "true")
-    
+    labels = [label["name"] for label in json.loads(os.environ.get("PR_LABELS", "[]"))]
     # Only act notify if the pull request is merged
     if not merged:
         print("Pull request is not merged. No notification will be sent.")
         exit(0)
         
+    if not NEW_PART in labels:
+        print(f"Pull request does not have the '{NEW_PART}' label. No notification will be sent.")
+        exit(0)
+    
     pr_title  = os.environ.get("PR_TITLE")
     pr_url    = os.environ.get("PR_URL")
     pr_author = os.environ.get("PR_AUTHOR")


### PR DESCRIPTION
## PR: Add Label-Based Filtering for Discord Notifications

### Summary

Enhances the GitHub → Discord notification workflow by ensuring notifications are sent only when a pull request is merged and contains the `newpart` label.

### Changes

* Added `PR_LABELS` environment variable using `toJson(github.event.pull_request.labels)`
* Parsed labels in `notify.py` using `json.loads`
* Added guard clause to exit if `newpart` label is not present
* Retained existing merged check logic

### Behavior

* Notify only if PR is merged
* Notify only if PR has `newpart` label
* Allows additional labels without restriction

### Rationale

Reduces noise and ensures notifications are limited to relevant, labeled changes.

### Reference

https://stackoverflow.com/questions/62325286/run-github-actions-when-pull-requests-have-a-specific-label
https://stackoverflow.com/questions/71481086/is-pull-request-label-available-to-a-github-action