### PR TITLE
Fix limit for segment in gdt entry

### DIFF
--- a/vm.c
+++ b/vm.c
@@ -32,8 +32,8 @@ switchuvm(struct proc *p)
     panic("switchuvm: no kstack");
 
   pushcli();
-  mycpu()->gdt[SEG_UCODE] = SEG(STA_X|STA_R, p->offset, (PROCSIZE << 12)-1, DPL_USER);
-  mycpu()->gdt[SEG_UDATA] = SEG(STA_W, p->offset, (PROCSIZE << 12)-1, DPL_USER);
+  mycpu()->gdt[SEG_UCODE] = SEG(STA_X|STA_R, p->offset, ((PROCSIZE -  1) << 12), DPL_USER);
+  mycpu()->gdt[SEG_UDATA] = SEG(STA_W, p->offset, ((PROCSIZE - 1) << 12), DPL_USER);
   lgdt(mycpu()->gdt, sizeof(mycpu()->gdt));
 
   mycpu()->gdt[SEG_TSS] = SEG16(STS_T32A, &mycpu()->ts,


### PR DESCRIPTION
Since PROCSIZE are multiples of 4KB, segment limit should be (PROCSIZE - 1)<<12 instead of (PROCSIZE<<12)-1