### PR TITLE
syscall: syswrite if condition(p19)

### DIFF
--- a/sysfile.c
+++ b/sysfile.c
@@ -70,9 +70,9 @@ sys_write(void)
   int n;
   char *p;
 
-  if((argfd(0, 0, &f) < 0) || (n=argstr(1, &p)) < 0) {
+  if(argfd(0, 0, &f) < 0 || argint(2, &n) < 0 || argptr(1, &p, n) < 0)
     return -1;
-  }
+  
   return filewrite(f, p, n);
 }
 


### PR DESCRIPTION
Currently, sys_write uses argstr() to fetch the user's buffer. Because argstr() treats the data as a null-terminated C string, it prematurely stops reading if the buffer contains a null byte (0x00).

Verified code from https://github.com/mit-pdos/xv6-public/blob/master/sysfile.c