### PR TITLE
Remove unused inode parameter from mknod

### DIFF
--- a/defs.h
+++ b/defs.h
@@ -31,7 +31,7 @@ int             mkdir(char *path);
 struct file*    open(char* path, int omode);
 int             unlink(char* path, char* name);
 int             isdirempty(struct inode *dp);
-int             mknod(struct inode *ip, char* path, int major, int minor);
+int             mknod(char* path, int major, int minor);
 
 // fs.c
 void            readsb(int dev, struct superblock *sb);

--- a/file.c
+++ b/file.c
@@ -281,8 +281,10 @@ open(char* path, int omode)
 }
 
 int
-mknod(struct inode *ip, char* path, int major, int minor)
+mknod(char* path, int major, int minor)
 {
+  struct inode *ip;
+
   begin_op();
   if((ip = create(path, T_DEV, major, minor)) == 0){
     end_op();

--- a/main.c
+++ b/main.c
@@ -47,8 +47,7 @@ main(void)
   iinit(ROOTDEV);  // Read superblock to start reading inodes
   initlog(ROOTDEV);  // Initialize log
 
-  struct inode console;
-  mknod(&console, "console", CONSOLE, CONSOLE);
+  mknod("console", CONSOLE, CONSOLE);
   seginit();       // segment descriptors
   pinit();         // first process
   scheduler();     // start running processes


### PR DESCRIPTION
`mknod` currently takes a `struct inode *ip`, but that argument is not usable by the caller. Inside `mknod`, the local pointer is overwritten with the result of `create()` and then immediately released with `iput()`, so the object passed from the caller is never populated (verified it by printing all attributes of the `console` ip after calling of `mknod` in `main.c`)

This change removes the dead parameter from the declaration, definition, and the `main.c` call site so that the API matches the function’s actual behavior. No functional change is intended.
