### PR TITLE
Fix memory leak in exec() on failure paths

### DIFF
--- a/exec.c
+++ b/exec.c
@@ -31,6 +31,7 @@ exec(char *path, char **argv)
 
   if((ip = namei(path)) == 0){
     end_op();
+    kfree(offset);
     cprintf("exec: fail\n");
     return -1;
   }
@@ -104,5 +105,6 @@ exec(char *path, char **argv)
     iput(ip);
     end_op();
   }
+  kfree(offset);
   return -1;
 }


### PR DESCRIPTION
**Summary**
This PR fixes one kernel bug introduced in the `p20-exec` branch affecting memory management.

**Specific Fix:**
* **Kernel Memory Leak (`exec.c`):** The `exec()` function allocates physical memory via `kalloc()` early in the function. If the target executable path is invalid (`namei(path) == 0`) or the ELF headers are malformed (jumping to the `bad:` label), the function previously returned `-1` without freeing the allocated memory. A user process could intentionally exhaust OS physical memory by repeatedly calling `exec` on invalid paths. Fixed by adding `kfree(offset)` to all failure paths.