### PR TITLE
Fix binary write truncation in sys_write

### DIFF
--- a/sysfile.c
+++ b/sysfile.c
@@ -70,7 +70,7 @@ sys_write(void)
   int n;
   char *p;
 
-  if((argfd(0, 0, &f) < 0) || (argstr(1, &p)) < 0 || (argint(2, &n)) < 0) {
+  if(argfd(0, 0, &f) < 0 || argint(2, &n) < 0 || argptr(1, &p, n) < 0) {
     return -1;
   }
   return filewrite(f, p, n);


### PR DESCRIPTION
**Summary**
This PR fixes one kernel bug introduced in the `p20-exec` branch affecting file I/O reliability.

**Specific Fix:**
* **Binary Write Truncation (`sysfile.c`):** `sys_write` was improperly using `argstr(1, &p)` to fetch the user buffer. Because `argstr` expects a NUL-terminated string, it compromises the ability to reliably write arbitrary binary data containing `\0` bytes. Changed to evaluate the size first with `argint(2, &n)` and then securely fetch the raw buffer using `argptr(1, &p, n)`, matching the safe implementation in `sys_read`.