### PR TITLE
Remove sti() call from scheduler

### DIFF
--- a/proc.c
+++ b/proc.c
@@ -127,9 +127,6 @@ scheduler(void)
   c->proc = 0;
   
   for(;;){
-    // Enable interrupts on this processor.
-    sti();
-
     // Loop over process table looking for process to run.
     for(p = ptable.proc; p < &ptable.proc[NPROC]; p++){
       if(p->state != RUNNABLE)


### PR DESCRIPTION
Do not enable interrupts in scheduler, same patch as [f47db98](https://github.com/codenet/col331/commit/f47db981c76653061df702cb7e2daa09b6010e03)