### PR TITLE
p20: use interrupt gate for syscalls

### DIFF
--- a/ide.c
+++ b/ide.c
@@ -142,11 +142,22 @@ iderw(struct buf *b)
     idestart(b);
 
   // Wait for request to finish.
-  while((b->flags & (B_VALID|B_DIRTY)) != B_VALID)
-  {
-    // Warning: If we do not call noop(), compiler generates code that does not
-    // read "b->flags" again and therefore never come out of this while loop. 
-    // "b->flags" is modified by the trap handler in ideintr().  
-    noop();
+  if(readeflags() & FL_IF) {
+    // Interrupts enabled: wait for ideintr to set B_VALID.
+    while((b->flags & (B_VALID|B_DIRTY)) != B_VALID) {
+      // Warning: If we do not call noop(), compiler generates code that does not
+      // read "b->flags" again and therefore never come out of this while loop.
+      // "b->flags" is modified by the trap handler in ideintr().
+      noop();
+    }
+  } else {
+    // Interrupts disabled: poll the disk directly since ideintr cannot fire.
+    if(!(b->flags & B_DIRTY) && idewait(1) >= 0)
+      insl(0x1f0, b->data, BSIZE/4);
+    b->flags |= B_VALID;
+    b->flags &= ~B_DIRTY;
+    idequeue = b->qnext;
+    if(idequeue != 0)
+      idestart(idequeue);
   }
 }

--- a/p19-syscall.md
+++ b/p19-syscall.md
@@ -35,12 +35,10 @@ kill the process upon seeing a general protection fault. Explicitly setting DPL
 in IDT is a protection mechanism so that processes cannot pretend to be hardware
 devices and call `int` instruction with their trap vectors.
 
-In addition, `tvinit` asks the hardware to *not* disable interrupts upon
-receiving a system call by declaring it a "trap gate". This is important to
-maintain responsiveness of the OS. A malicious process can give a lot of work to
-the OS via system calls. If the hardware disabled interrupts during syscall
-handling, the process will be able to exceed its time quanta and make the OS
-unresponsive to keyboard etc. 
+At this stage, `tvinit` declares the system call as an interrupt gate, so the
+hardware disables interrupts while handling system calls. This keeps things
+simple for now; we will change this to a trap gate in p21 when we introduce
+proper synchronization to handle the resulting concurrency.
 
 Trap handler in `trap.c` hands over to `syscall` which reads process' `eax`
 register from the trapframe to figure out which system call is the process

--- a/trap.c
+++ b/trap.c
@@ -18,7 +18,7 @@ tvinit(void)
 
   for(i = 0; i < 256; i++)
     SETGATE(idt[i], 0, SEG_KCODE<<3, vectors[i], 0);
-  SETGATE(idt[T_SYSCALL], 1, SEG_KCODE<<3, vectors[T_SYSCALL], DPL_USER);
+  SETGATE(idt[T_SYSCALL], 0, SEG_KCODE<<3, vectors[T_SYSCALL], DPL_USER);
 }
 
 void


### PR DESCRIPTION
- Change syscall IDT entry from trap gate to interrupt gate in `trap.c`
- Fix `ide.c` to poll disk directly when interrupts are disabled

p19 does not need the `ide.c` fix because `exec` is not yet implemented there — no user process calls `iderw`. The only disk I/O in p19 is `iinit`/`initlog` called from `main.c` after `sti()`, so interrupts are on and `ideintr` fires normally.

p20 adds `exec`. The init process calls `exec("/init")` which reads the binary from disk, so `iderw` is now called from inside the `exec` syscall handler. With the interrupt gate, the hardware clears IF on syscall entry, keeping interrupts disabled for the duration of the syscall. The old `iderw` busy-waited for `ideintr` to set `B_VALID`, but `ideintr` can never fire with IF=0, causing a hang(upon running make qemu). The fix checks IF before waiting: if disabled, poll the disk directly instead.