### PR TITLE
Fix memory leak in allocproc when kstack kalloc fails

### DIFF
--- a/proc.c
+++ b/proc.c
@@ -68,6 +68,8 @@ found:
   // kstack lives on a different segment
   if((p->kstack = kalloc()) == 0){
     p->state = UNUSED;
+    kfree(p->offset);
+    p->offset = 0;
     return 0;
   }
 


### PR DESCRIPTION
When kalloc() for p->offset succeeds but kalloc() for p->kstack
  subsequently fails, p->offset is never freed before returning 0.
  This leaks a 1MB page permanently since p->state is reset to UNUSED,
  making the pointer unreachable.