### PR TITLE
Fix memory leak in wait(): kstack block never freed

### DIFF
--- a/proc.c
+++ b/proc.c
@@ -313,6 +313,8 @@ wait(void)
         pid = p->pid;
         kfree(p->offset); // Free the 1MB physical block
         p->offset = 0;
+        kfree(p->kstack + KSTACKSIZE - PGSIZE);
+        p->kstack = 0;
         p->pid = 0;
         p->parent = 0;
         p->name[0] = 0;


### PR DESCRIPTION
In allocproc(), kalloc() is called twice — once for p->offset (block A) and once for p->kstack (block B). p->kstack is then advanced by PGSIZE - KSTACKSIZE, so the original start of
  block B is no longer stored anywhere.

  In wait(), only block A is freed via kfree(p->offset). Block B is never freed — its start address is unrecoverable once p->state = UNUSED and allocproc overwrites p->kstack on the next
  allocation. This leaks 1MB per process exit permanently.

  Fix: recover block_B_start as p->kstack + KSTACKSIZE - PGSIZE before clearing p->kstack.