### PR TITLE
fix bug: avoid lost-wakeup race in acquiresleep

### DIFF
--- a/sleeplock.c
+++ b/sleeplock.c
@@ -20,9 +20,7 @@ acquiresleep(struct sleeplock *lk)
 {
   pushcli();
   while (lk->locked) {
-    popcli();
-    sleep(lk);
-    pushcli();
+    sleep(lk);   // sleep atomically with interrupts still disabled
   }
   lk->locked = 1;
   lk->pid = myproc()->pid;


### PR DESCRIPTION
Problem
acquiresleep() had a lost-wakeup race.
Inside the wait loop, it re-enabled interrupts (popcli) before calling sleep(lk). If another process released the sleeplock and called wakeup(lk) in that small window, the wakeup could be missed, causing the waiting process to sleep indefinitely (potential deadlock).

Fix
Keep interrupts disabled across the entire wait-check-to-sleep sequence in acquiresleep().
Specifically, remove the popcli()/pushcli() pair inside the while (lk->locked) loop and call sleep(lk) directly while still under the existing interrupt-disabled context. This closes the race window and ensures wakeups are not missed during sleeplock acquisition.