### PR TITLE
fix: free kernel stack page when reaping zombie in wait()

### DIFF
--- a/proc.c
+++ b/proc.c
@@ -311,6 +311,8 @@ wait(void)
       // If we find a ZOMBIE child, clean up its memory!
       if(p->state == ZOMBIE){
         pid = p->pid;
+        kfree(p->kstack);
+        p->kstack = 0;
         kfree(p->offset); // Free the 1MB physical block
         p->offset = 0;
         p->pid = 0;


### PR DESCRIPTION
Problem
When a child becomes ZOMBIE, wait() frees p->offset but never frees p->kstack. Every reaped child leaks one kernel-stack page allocated in allocproc().

Fix
Call kfree(p->kstack) and clear p->kstack before freeing the user segment, same pattern as p->offset.