### PR TITLE
Fix sys_mknod to use iunlockput instead of iput

### DIFF
--- a/sysfile.c
+++ b/sysfile.c
@@ -197,7 +197,7 @@ sys_mknod(void)
     end_op();
     return -1;
   }
-  iput(ip);
+  iunlockput(ip);
   end_op();
   return 0;
 }


### PR DESCRIPTION
  `create()` returns with the inode's sleeplock held. `sys_mknod` calls
  `iput(ip)` which only decrements the reference count — it does not                                                 
  release the sleeplock, leaving `ip->lock` permanently acquired.                                                    
                                                                                                                     
  Any subsequent `ilock()` on the same cached inode entry will call                                                  
  `acquiresleep`, see `locked=1`, and sleep indefinitely — a deadlock.                                               
                                                                                                                     
  In practice this is avoided by coincidence: `iput` drops the reference                                             
  count to 0, so the next `iget` for the same inode treats the cache slot                                            
  as empty and calls `initsleeplock`, resetting the lock. But if any other                                           
  process holds a reference to the inode concurrently (keeping ref >= 1),                                            
  `iget` returns the cached entry with the lock still held, and the next                                             
  `ilock` deadlocks.                                                                                                 
                                                                                                                     
  Every other caller of `create()` in `sysfile.c` correctly uses                                                     
  `iunlockput(ip)` (or `iunlock(ip)`) before releasing the inode.                                                    
  Fix `sys_mknod` to do the same.   