### PR TITLE
fix: free user page if kernel stack alloc fails in allocproc

### DIFF
--- a/proc.c
+++ b/proc.c
@@ -70,6 +70,8 @@ found:
 
   // kstack lives on a different segment
   if((p->kstack = kalloc()) == 0){
+    kfree(p->offset);
+    p->offset = 0;
     p->state = UNUSED;
     return 0;
   }


### PR DESCRIPTION
Problem
In allocproc(), if the first kalloc() succeeds for p->offset but the second kalloc() fails for p->kstack, the process slot is marked UNUSED and the function returns without reclaiming the user page. That leaks one physical page per failed allocation.

Someone already opened a PR that adds kfree(p->offset) on that failure path, which fixes the leak. They did not set p->offset = 0 afterward, so the struct proc can still hold a stale pointer into freed memory until the slot is fully reused. Clearing the pointer after kfree matches the usual pattern (e.g. zombie cleanup in wait()), avoids confusion when debugging, and prevents any accidental use of a freed address if code paths change later.

Description of the fix
On kernel-stack allocation failure, after freeing the user segment page with kfree(p->offset), set p->offset = 0 before setting p->state = UNUSED and returning. That completes the earlier PR: same leak fix, plus a safe, explicit null of the freed pointer so the proc structure does not retain a dangling reference