### PR TITLE
fix(p26): add curproc->offset in argptr for correct user-ptr translation

### DIFF
--- a/syscall.c
+++ b/syscall.c
@@ -66,7 +66,7 @@ argptr(int n, char **pp, int size)
     return -1;
   if(size < 0 || (uint)i >= curproc->sz || (uint)i+size > curproc->sz)
     return -1;
-  *pp = (char*)i;
+  *pp = (char*)(curproc->offset + i);
   return 0;
 }
 


### PR DESCRIPTION
**Summary**
This PR fixes a critical memory translation bug in `syscall.c` where `argptr()` failed to add the process's physical memory offset to user virtual addresses. This caused system calls that rely on pointer arguments (like `write`) to read from the wrong physical memory locations.

**Specific Fixes:**
 In our memory model, a user process's physical memory is offset by `curproc->offset`. While helpers like `fetchint` and `fetchstr` correctly applied this offset, `argptr()` was incorrectly returning the raw user virtual address as a kernel pointer. 
Because `sys_write` uses `argptr()` to fetch the string buffer from the user, it was passing an invalid physical address down to `filewrite()`. This resulted in corrupted and garbled text being printed to the console when `init.c` called `printf`.
Updated `argptr()` to correctly translate the address by adding the physical base offset: `*pp = (char*)(curproc->offset + i);`.

**Verification:**
After applying this fix, `argptr()` successfully returns the correct physical memory addresses. Programs like `init.c` can now correctly pass buffers to `sys_write` and print expected output to the console without corruption.
