### PR TITLE
fix: update curproc->sz after loading new program in exec

### DIFF
--- a/exec.c
+++ b/exec.c
@@ -97,6 +97,7 @@ exec(char *path, char **argv)
   // messed up, otherwise!
   kfree(curproc->offset);
   curproc->offset = offset;
+  curproc->sz = PGSIZE;
   switchuvm(curproc);
   return 0;
 

--- a/proc.c
+++ b/proc.c
@@ -65,6 +65,7 @@ found:
 
   // kstack lives on a different segment
   if((p->kstack = kalloc()) == 0){
+    kfree(p->offset);
     p->state = UNUSED;
     return 0;
   }


### PR DESCRIPTION
exec() replaces the process's address space by calling kfree(curproc->offset) and assigning a new offset, but never updates curproc->sz.
This is a problem because fetchint() and fetchstr() in syscall.c use curproc->sz for bounds checking. With a stale sz value, valid user addresses could be incorrectly rejected, or invalid ones could slip through.
Fixed by setting curproc->sz = PGSIZE right after updating curproc->offset, matching the size of the newly allocated segment.