### PR TITLE
Fix missing verb in volatile description

### DIFF
--- a/01/README.md
+++ b/01/README.md
@@ -58,7 +58,7 @@ Under Linux you can disable ASLR, without using a debugger, in (at least)  two w
 * ```volatile int counter = 0```
 
 Volatile is used to indicate to the compiler that a variable's value may change
-unexpectedly.  i.e, the compiler can't assume that the value of the variable
+unexpectedly.  i.e., the compiler can't assume that the value of the variable
 won't change if it is not written to.  Volatile is needed to make sure that
 compiler doesn't do any optimisations such as storing the value of counter in
 any temporary variables.  But still, we are trying to access the value of the

--- a/01/README.md
+++ b/01/README.md
@@ -58,7 +58,7 @@ Under Linux you can disable ASLR, without using a debugger, in (at least)  two w
 * ```volatile int counter = 0```
 
 Volatile is used to indicate to the compiler that a variable's value may change
-unexpectedly.  i.e., the compiler can't assume that the value of the variable
+unexpectedly;  i.e., the compiler can't assume that the value of the variable
 won't change if it is not written to.  Volatile is needed to make sure that
 compiler doesn't do any optimisations such as storing the value of counter in
 any temporary variables.  But still, we are trying to access the value of the

--- a/01/README.md
+++ b/01/README.md
@@ -57,7 +57,7 @@ Under Linux you can disable ASLR, without using a debugger, in (at least)  two w
 ## FAQ
 * ```volatile int counter = 0```
 
-Volatile used to indicate to the compiler that a variable's value may change
+Volatile is used to indicate to the compiler that a variable's value may change
 unexpectedly.  i.e, the compiler can't assume that the value of the variable
 won't change if it is not written to.  Volatile is needed to make sure that
 compiler doesn't do any optimisations such as storing the value of counter in


### PR DESCRIPTION
01/README.md: "Volatile used to indicate" → "Volatile is used to indicate"