### PR TITLE
bug in p28-kill:set killed=1 on unexpected user-space traps

### DIFF
--- a/trap.c
+++ b/trap.c
@@ -66,6 +66,12 @@ trap(struct trapframe *tf)
               tf->trapno, cpuid(), tf->eip, rcr2());
       panic("trap");
     }
+    // In user space, assume process misbehaved.
+    cprintf("pid %d %s: trap %d err %d on cpu %d "
+            "eip 0x%x addr 0x%x--kill proc\n",
+            myproc()->pid, myproc()->name, tf->trapno,
+            tf->err, cpuid(), tf->eip, rcr2());
+    myproc()->killed = 1;
   }
 
   // Force process to exit if it has been killed and is in user space.


### PR DESCRIPTION
## What I noticed
While working through `p28-kill`, I wrote a small user program that runs an illegal instruction (`ud2`) to see how the kernel handles it. I expected the process to get killed, since that's what this branch is about. Instead the shell just froze.

## The bug
In `trap.c`, the `default` case of the trap switch only does something for kernel-mode traps:

'''
default:
  if(myproc() == 0 || (tf->cs&3) == 0){
    cprintf("unexpected trap %d ...");
    panic("trap");
  }
'''

For a user-mode trap (divide-by-zero, illegal opcode, page fault, etc.), the `if` is false and the whole block is skipped. Of the three checks sitting below the switch, two only fire if `myproc()->killed` is set and the third only fires on the timer interrupt — so for an unexpected user trap, none of them do anything. `trap()` returns, `iret` goes back to the faulting instruction, and the process spins on the same fault forever.

## The fix
Match `xv6-public`: after the kernel-panic block, print a `--kill proc` message and set `myproc()->killed = 1`. The existing `if(myproc() && myproc()->killed && (tf->cs&3) == DPL_USER) exit();` check below the switch then calls `exit()` on the way back to user mode. 6 new lines, no control-flow changes.

## Verifying
- Builds clean with `-Werror -Wall`, no new warnings.
- Normal programs (`ls`, `cat`, `echo`) still work.
- My `ud2` test program now prints the `--kill proc` message and the shell comes back, instead of hanging.

## Scope
Same default case exists unchanged on `p28-kill` through `p31-umalloc`. Opening this against `p28-kill` since that's the earliest branch where the `killed`-enforcement machinery exists and the fix applies.