### PR TITLE
fix(log): remove duplicate pushcli in log_write

### DIFF
--- a/log.c
+++ b/log.c
@@ -220,7 +220,7 @@ log_write(struct buf *b)
   if (log.outstanding < 1)
     panic("log_write outside of trans");
 
-  pushcli();
+
   for (i = 0; i < log.lh.n; i++) {
     if (log.lh.block[i] == b->blockno)   // log absorption
       break;


### PR DESCRIPTION
### Bug
`log_write` in `log.c` calls `pushcli()` twice but `popcli()` only once. 

### Fix
Drop the duplicate `pushcli()` so the function has balanced 
`pushcli()` / `popcli()`.