### PR TITLE
fix(mmu): remove duplicate NSEGS definition

### DIFF
--- a/mmu.h
+++ b/mmu.h
@@ -51,8 +51,6 @@ struct segdesc {
 #define STA_W       0x2     // Writeable (non-executable segments)
 #define STA_R       0x2     // Readable (executable segments)
 
-// cpu->gdt[NSEGS] holds the above segments.
-#define NSEGS     6
 
 #define DPL_USER    0x3     // User DPL
 


### PR DESCRIPTION
### Problem
`mmu.h` defined `NSEGS` (and the same leading comment) twice —
once near the `SEG_*` selector block and again after the `STA_*`
bits.
### Fix
Remove the second copy of the comment + `#define NSEGS 6`.