### PR TITLE
fixed bug, missing header for assert is added

### DIFF
--- a/08/Makefile
+++ b/08/Makefile
@@ -1,4 +1,5 @@
 all: p1 p2 p3 p4 fork-cow fork-fd fork-fd2 pipe dup nodup
 
 clean:
-	rm p1 p2 p3 p4 fork-cow fork-fd fork-fd2 pipe dup nodup
+	rm -f p1 p2 p3 p4 fork-cow fork-fd fork-fd2 pipe dup nodup \
+	      dup.txt nodup.txt fd.txt fd2.txt p4.output

--- a/08/p3.c
+++ b/08/p3.c
@@ -3,6 +3,7 @@
 #include <unistd.h>
 #include <string.h>
 #include <sys/wait.h>
+#include <assert.h>
 
 int
 main(int argc, char *argv[])


### PR DESCRIPTION
The code for the p3.c was not compiling because of the missing header for the assert function call
Added #include <assert.h> header file