### PR TITLE
Add fsync binary to clean target in 05/Makefile in main branch

### DIFF
--- a/05/Makefile
+++ b/05/Makefile
@@ -1,7 +1,7 @@
 all: io fsync
 
 clean:
-	rm -f io
+	rm -f io fsync
 
 io: io.c common.h
 	gcc -o io io.c -Wall


### PR DESCRIPTION
The all target builds two binaries — io and fsync — but the clean target only removes io. After running `make` and then `make clean`, the fsync executable is left behind in the working tree.

Added fsync to the rm -f line so clean removes both binaries.